### PR TITLE
Make totals automatic in serializers

### DIFF
--- a/Backend/core/serializers/quotes.py
+++ b/Backend/core/serializers/quotes.py
@@ -9,6 +9,7 @@ class QuoteDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = QuoteDetail
         fields = ['product_id', 'quantity', 'price_unit', 'subtotal', 'iva']
+        read_only_fields = ['price_unit', 'subtotal', 'iva']
 
 
 class QuoteSerializer(serializers.ModelSerializer):

--- a/Backend/core/serializers/sales.py
+++ b/Backend/core/serializers/sales.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from core.models import Sale, SaleDetail, Product
+from core.models import Sale, SaleDetail, Product, PaymentMethod
 
 
 class SaleDetailSerializer(serializers.ModelSerializer):
@@ -8,11 +8,15 @@ class SaleDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = SaleDetail
         fields = ['product_id', 'quantity', 'price_unit', 'subtotal', 'iva']
+        read_only_fields = ['price_unit', 'subtotal', 'iva']
 
 
 class SaleSerializer(serializers.ModelSerializer):
     details = SaleDetailSerializer(many=True)
     agent = serializers.HiddenField(default=serializers.CurrentUserDefault())
+    payment_method = serializers.PrimaryKeyRelatedField(
+        queryset=PaymentMethod.objects.all(), allow_null=True, required=False
+    )
 
     class Meta:
         model = Sale


### PR DESCRIPTION
## Summary
- sales: make payment method optional and auto-calc item fields
- quotes: auto-calc price fields

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686eee5e45d8832ca08193f59a6db0b6