### PR TITLE
Add PaymentMethod endpoint

### DIFF
--- a/Backend/core/serializers/__init__.py
+++ b/Backend/core/serializers/__init__.py
@@ -1,1 +1,2 @@
 from .products import ProductSerializer
+from .payment_methods import PaymentMethodSerializer

--- a/Backend/core/serializers/payment_methods.py
+++ b/Backend/core/serializers/payment_methods.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from core.models import PaymentMethod
+
+class PaymentMethodSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PaymentMethod
+        fields = '__all__'

--- a/Backend/core/urls.py
+++ b/Backend/core/urls.py
@@ -1,6 +1,13 @@
 from rest_framework.routers import DefaultRouter
 from django.urls import path, include
-from core.views import ProductViewSet, SaleViewSet, QuoteViewSet, SalesSummaryReportView, CategoryViewSet
+from core.views import (
+    ProductViewSet,
+    SaleViewSet,
+    QuoteViewSet,
+    SalesSummaryReportView,
+    CategoryViewSet,
+    PaymentMethodViewSet,
+)
 from django.conf import settings
 from django.conf.urls.static import static
 
@@ -9,6 +16,7 @@ router.register(r'products', ProductViewSet, basename='products')
 router.register(r'sales', SaleViewSet, basename='sales')
 router.register(r'quotes', QuoteViewSet, basename='quotes')
 router.register(r'categories', CategoryViewSet, basename='categories')
+router.register(r'payment-methods', PaymentMethodViewSet, basename='payment-methods')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/Backend/core/views/__init__.py
+++ b/Backend/core/views/__init__.py
@@ -3,5 +3,6 @@ from .sales import SaleViewSet
 from .quotes import QuoteViewSet
 from .reports import SalesSummaryReportView
 from .categories import CategoryViewSet
+from .payment_methods import PaymentMethodViewSet
 
 

--- a/Backend/core/views/payment_methods.py
+++ b/Backend/core/views/payment_methods.py
@@ -1,0 +1,10 @@
+from rest_framework import viewsets, permissions
+from drf_spectacular.utils import extend_schema
+from core.models import PaymentMethod
+from core.serializers.payment_methods import PaymentMethodSerializer
+
+@extend_schema(tags=["Métodos de Pago"])
+class PaymentMethodViewSet(viewsets.ModelViewSet):
+    queryset = PaymentMethod.objects.all()
+    serializer_class = PaymentMethodSerializer
+    permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
## Summary
- implement serializer and viewset for `PaymentMethod`
- expose new endpoint via router
- export view and serializer modules

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ef6a301b8832cb7827bcc50fd4f81