### PR TITLE
Fix sale creation with default totals

### DIFF
--- a/Backend/core/serializers/sales.py
+++ b/Backend/core/serializers/sales.py
@@ -29,7 +29,10 @@ class SaleSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         details_data = validated_data.pop('details')
-        sale = Sale.objects.create(**validated_data)
+        # ``Sale`` requires ``total`` and ``iva`` values. Provide temporary
+        # defaults so the instance can be created before calculating them from
+        # the details data.
+        sale = Sale.objects.create(total=0, iva=0, **validated_data)
 
         total = 0
         iva_total = 0


### PR DESCRIPTION
## Summary
- ensure `Sale` is created with placeholder values for `total` and `iva`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef8e1115c832cbe7d50d21a120dd6