### PR TITLE
Fix Decimal multiplication in sales serializer

### DIFF
--- a/Backend/core/serializers/sales.py
+++ b/Backend/core/serializers/sales.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from rest_framework import serializers
 from core.models import Sale, SaleDetail, Product, PaymentMethod
 
@@ -32,16 +33,16 @@ class SaleSerializer(serializers.ModelSerializer):
         # ``Sale`` requires ``total`` and ``iva`` values. Provide temporary
         # defaults so the instance can be created before calculating them from
         # the details data.
-        sale = Sale.objects.create(total=0, iva=0, **validated_data)
+        sale = Sale.objects.create(total=Decimal('0'), iva=Decimal('0'), **validated_data)
 
-        total = 0
-        iva_total = 0
+        total = Decimal('0')
+        iva_total = Decimal('0')
         for item in details_data:
             product = Product.objects.get(pk=item['product_id'])
             quantity = item['quantity']
             price = product.price
             subtotal = round(price * quantity, 2)
-            iva = round(subtotal * 0.19, 2)
+            iva = round(subtotal * Decimal('0.19'), 2)
 
             # Descontar stock
             product.stock -= quantity


### PR DESCRIPTION
## Summary
- ensure decimal arithmetic when calculating IVA and totals

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686efbdbaaa0832c968a2ece151f1aa9