### PR TITLE
Implement basic frontend login

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,35 +1,31 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-
+import Login from './Login.jsx'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [user, setUser] = useState(null)
+  const [token, setToken] = useState(localStorage.getItem('access') || '')
+
+  const handleLogin = (u, t) => {
+    setUser(u)
+    setToken(t)
+  }
+
+  if (!token) {
+    return (
+      <div className="p-4">
+        <h1 className="text-2xl mb-4">Iniciar Sesión</h1>
+        <Login onSuccess={handleLogin} />
+      </div>
+    )
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1 className='bg-red-500'>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="p-4">
+      <h1 className="text-2xl">Bienvenido, {user?.username}</h1>
+      <p>Rol: {user?.role}</p>
+    </div>
   )
 }
 
 export default App
+

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+
+function Login({ onSuccess }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+    try {
+      const resp = await fetch('http://localhost:8000/api/login/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      })
+      if (!resp.ok) {
+        throw new Error('Credenciales incorrectas')
+      }
+      const data = await resp.json()
+      localStorage.setItem('access', data.access)
+      localStorage.setItem('refresh', data.refresh)
+      if (onSuccess) onSuccess(data.user, data.access)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-sm mx-auto">
+      <input
+        type="text"
+        placeholder="Usuario"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        className="border p-2 w-full"
+      />
+      <input
+        type="password"
+        placeholder="Contraseña"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="border p-2 w-full"
+      />
+      {error && <div className="text-red-500">{error}</div>}
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2 w-full">
+        Iniciar sesión
+      </button>
+    </form>
+  )
+}
+
+export default Login


### PR DESCRIPTION
## Summary
- add a `Login` component to handle credential submission and token storage
- update `App` to show login form and display logged in user info

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6875aceaa72c832c992bb4e5920fc2d6