### PR TITLE
Allow public read access

### DIFF
--- a/Backend/core/views/categories.py
+++ b/Backend/core/views/categories.py
@@ -8,4 +8,4 @@ from drf_spectacular.utils import extend_schema
 class CategoryViewSet(viewsets.ModelViewSet):
     queryset = Category.objects.filter(is_active=True).order_by('id')
     serializer_class = CategorySerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/Backend/core/views/payment_methods.py
+++ b/Backend/core/views/payment_methods.py
@@ -7,4 +7,4 @@ from core.serializers.payment_methods import PaymentMethodSerializer
 class PaymentMethodViewSet(viewsets.ModelViewSet):
     queryset = PaymentMethod.objects.all()
     serializer_class = PaymentMethodSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/Backend/core/views/products.py
+++ b/Backend/core/views/products.py
@@ -1,7 +1,7 @@
 from rest_framework import viewsets
 from core.models import Product
 from core.serializers.products import ProductSerializer
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 from drf_spectacular.utils import extend_schema
 
 
@@ -9,7 +9,7 @@ from drf_spectacular.utils import extend_schema
 class ProductViewSet(viewsets.ModelViewSet):
     queryset = Product.objects.all()
     serializer_class = ProductSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticatedOrReadOnly]
 
     def perform_create(self, serializer):
         serializer.save(created_by=self.request.user)


### PR DESCRIPTION
## Summary
- loosen permissions for products, categories and payment methods API

## Testing
- `python -m py_compile Backend/core/views/products.py Backend/core/views/categories.py Backend/core/views/payment_methods.py`

------
https://chatgpt.com/codex/tasks/task_e_6875c37b1ae0832cb59fa3ddb5997090