### PR TITLE
Improve product list UX

### DIFF
--- a/frontend/src/components/Ventas/Pagination.jsx
+++ b/frontend/src/components/Ventas/Pagination.jsx
@@ -2,6 +2,20 @@
 function Pagination({ page, totalPages, onPageChange }) {
   if (totalPages <= 1) return null
 
+  const getPages = () => {
+    if (totalPages <= 7) return Array.from({ length: totalPages }, (_, i) => i + 1)
+    const pages = [1]
+    let start = Math.max(2, page - 1)
+    let end = Math.min(totalPages - 1, page + 1)
+    if (start > 2) pages.push('...')
+    for (let i = start; i <= end; i++) pages.push(i)
+    if (end < totalPages - 1) pages.push('...')
+    pages.push(totalPages)
+    return pages
+  }
+
+  const pages = getPages()
+
   return (
     <div className="mt-6 flex justify-center items-center space-x-2">
       <button
@@ -10,17 +24,23 @@ function Pagination({ page, totalPages, onPageChange }) {
       >
         {'<'}
       </button>
-      {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
-        <button
-          key={n}
-          onClick={() => onPageChange(n)}
-          className={`px-2 rounded ${
-            page === n ? 'font-bold text-black' : 'text-gray-400'
-          }`}
-        >
-          {n}
-        </button>
-      ))}
+      {pages.map((n, idx) =>
+        n === '...' ? (
+          <span key={`ellipsis-${idx}`} className="px-2">
+            ...
+          </span>
+        ) : (
+          <button
+            key={n}
+            onClick={() => onPageChange(n)}
+            className={`px-2 rounded ${
+              page === n ? 'font-bold text-black' : 'text-gray-400'
+            }`}
+          >
+            {n}
+          </button>
+        )
+      )}
       <button
         onClick={() => onPageChange(Math.min(totalPages, page + 1))}
         className="px-2 text-xl"

--- a/frontend/src/components/Ventas/ProductCard.jsx
+++ b/frontend/src/components/Ventas/ProductCard.jsx
@@ -20,7 +20,7 @@ function ProductCard({ product, quantity, onQuantityChange, onAdd }) {
       )}
 
       {/* Imagen del producto */}
-      <div className="relative bg-gradient-to-br from-gray-50 to-gray-100 p-3 flex items-center justify-center h-32">
+        <div className="relative bg-gradient-to-br from-gray-50 to-gray-100 p-2 flex items-center justify-center h-24">
         <img
           src={product.image}
           alt={product.name}

--- a/frontend/src/pages/Ventas.jsx
+++ b/frontend/src/pages/Ventas.jsx
@@ -5,7 +5,7 @@ import ProductRow from '@components/ventas/ProductRow.jsx'
 import CartSummary from '@components/ventas/CartSummary.jsx'
 import Pagination from '@components/ventas/Pagination.jsx'
 
-const PER_PAGE_GRID = 6
+const PER_PAGE_GRID = 12
 const PER_PAGE_LIST = 15
 
 function Ventas() {
@@ -194,45 +194,47 @@ function Ventas() {
                 </span>
               </div>
               
-              {productsToShow.length > 0 ? (
-                viewMode === 'grid' ? (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
-                    {productsToShow.map((p) => (
-                      <ProductCard
-                        key={p.id}
-                        product={p}
-                        quantity={qtyMap[p.id] || 1}
-                        onQuantityChange={(val) => handleQtyChange(p.id, val)}
-                        onAdd={() => handleAdd(p)}
-                      />
-                    ))}
-                  </div>
+              <div className="max-h-[65vh] overflow-y-auto">
+                {productsToShow.length > 0 ? (
+                  viewMode === 'grid' ? (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-6 gap-3">
+                      {productsToShow.map((p) => (
+                        <ProductCard
+                          key={p.id}
+                          product={p}
+                          quantity={qtyMap[p.id] || 1}
+                          onQuantityChange={(val) => handleQtyChange(p.id, val)}
+                          onAdd={() => handleAdd(p)}
+                        />
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="space-y-2">
+                      {productsToShow.map((p) => (
+                        <ProductRow
+                          key={p.id}
+                          product={p}
+                          quantity={qtyMap[p.id] || 1}
+                          onQuantityChange={(val) => handleQtyChange(p.id, val)}
+                          onAdd={() => handleAdd(p)}
+                        />
+                      ))}
+                    </div>
+                  )
                 ) : (
-                  <div className="space-y-2">
-                    {productsToShow.map((p) => (
-                      <ProductRow
-                        key={p.id}
-                        product={p}
-                        quantity={qtyMap[p.id] || 1}
-                        onQuantityChange={(val) => handleQtyChange(p.id, val)}
-                        onAdd={() => handleAdd(p)}
-                      />
-                    ))}
+                  <div className="text-center py-12">
+                    <div className="text-gray-400 mb-3">
+                      <svg className="h-12 w-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+                      </svg>
+                    </div>
+                    <p className="text-gray-500 text-base">No se encontraron productos</p>
+                    <p className="text-gray-400 text-xs mt-1">
+                      Intenta cambiar los filtros o la búsqueda
+                    </p>
                   </div>
-                )
-              ) : (
-                <div className="text-center py-12">
-                  <div className="text-gray-400 mb-3">
-                    <svg className="h-12 w-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
-                    </svg>
-                  </div>
-                  <p className="text-gray-500 text-base">No se encontraron productos</p>
-                  <p className="text-gray-400 text-xs mt-1">
-                    Intenta cambiar los filtros o la búsqueda
-                  </p>
-                </div>
-              )}
+                )}
+              </div>
 
               {/* Paginación */}
               {pageCount > 1 && (


### PR DESCRIPTION
## Summary
- display fewer page numbers using ellipsis
- reduce card size for denser grid
- show more products per page
- allow scrolling inside product list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68781f536c6c832c88d941efe2c31a85