### PR TITLE
Fix Inventario page loading data

### DIFF
--- a/frontend/src/pages/Inventario.jsx
+++ b/frontend/src/pages/Inventario.jsx
@@ -16,14 +16,19 @@ function Inventario() {
   const authHeaders = { Authorization: `Bearer ${token}` }
 
   const fetchData = () => {
-    fetch('http://192.168.1.52:8000/api/products/', { headers })
-      .then((r) => r.json())
-      .then(setProducts)
+    setLoading(true)
+    Promise.all([
+      fetch('http://192.168.1.52:8000/api/products/', { headers: authHeaders }).then((r) => r.json()),
+      fetch('http://192.168.1.52:8000/api/categories/', {
+        headers: authHeaders,
+      }).then((r) => r.json()),
+    ])
+      .then(([prods, cats]) => {
+        setProducts(prods)
+        setCategories(cats)
+      })
       .catch((e) => console.error(e))
-    fetch('http://192.168.1.52:8000/api/categories/', { headers })
-      .then((r) => r.json())
-      .then(setCategories)
-      .catch((e) => console.error(e))
+      .finally(() => setLoading(false))
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fetch products and categories with auth headers
- show inventory once data is loaded

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687843a9ecd8832c9acbf7af1deaa58b