### PR TITLE
Fix quote PDF export error

### DIFF
--- a/frontend/src/pages/Cotizaciones.jsx
+++ b/frontend/src/pages/Cotizaciones.jsx
@@ -114,6 +114,7 @@ function Cotizaciones() {
       const pdfResp = await fetch(`http://192.168.1.52:8000/api/quotes/${data.id}/export/`, {
         headers: { Authorization: `Bearer ${token}` },
       })
+      if (!pdfResp.ok) throw new Error('Error al generar PDF de cotización')
       const pdfData = await pdfResp.json()
       window.open(pdfData.pdf_url, '_blank')
       setShowQuotes(true)


### PR DESCRIPTION
## Summary
- fix error handling when generating PDF for a new quote

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6878702cf854832cb303df3c225ff0d4