### PR TITLE
Fix PDF export errors

### DIFF
--- a/Backend/core/templates/quotes/pdf.html
+++ b/Backend/core/templates/quotes/pdf.html
@@ -7,9 +7,6 @@
     @page {
       size: A4;
       margin: 20mm;
-      @bottom-center {
-        content: "Página " counter(page) " de " counter(pages);
-      }
     }
     
     body {
@@ -251,6 +248,7 @@
   </div>
   
   <div class="footer">
+    <p>Página <pdf:pagenumber> de <pdf:pagecount></p>
     <p><strong>¡Gracias por su preferencia!</strong></p>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- remove unsupported `@bottom-center` CSS rule from quote PDF template
- add page numbers with xhtml2pdf tags to footer

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6878725fca24832c83129beb65383fa8