### PR TITLE
Add product detail modal and barcode display

### DIFF
--- a/frontend/src/components/Inventario/InventoryRow.jsx
+++ b/frontend/src/components/Inventario/InventoryRow.jsx
@@ -24,7 +24,10 @@ function InventoryRow({ product, onEdit, onDelete }) {
       
       {/* Información */}
       <div className="flex-1 min-w-0">
-        <h3 className="font-medium text-sm text-gray-900 truncate">{product.name}</h3>
+        <h3 className="font-medium text-sm text-gray-900 truncate mb-0.5">{product.name}</h3>
+        {product.barcode && (
+          <p className="text-xs text-gray-500 truncate mb-1">Cod: {product.barcode}</p>
+        )}
         <div className="flex items-center space-x-2 text-xs">
           <span className="text-gray-500">Stock:</span>
           <span

--- a/frontend/src/components/ProductDetailModal.jsx
+++ b/frontend/src/components/ProductDetailModal.jsx
@@ -1,0 +1,66 @@
+// src/components/ProductDetailModal.jsx
+function ProductDetailModal({ open, onClose, product }) {
+  if (!open || !product) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-2xl p-6">
+        <div className="flex justify-between items-start mb-4">
+          <h2 className="text-xl font-semibold text-gray-800 flex-1">
+            {product.name}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700"
+          >
+            &#10005;
+          </button>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="flex items-center justify-center">
+            <img
+              src={product.image}
+              alt={product.name}
+              className="max-h-60 object-contain"
+              onError={(e) => {
+                e.target.src =
+                  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTIwIDdMMTYgM0g4TDQgN1YxN0E0IDQgMCAwIDAgOCAyMUgxNkE0IDQgMCAwIDAgMjAgMTdWN1oiIHN0cm9rZT0iIzlDQTNBRiIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTkgMTFBMyAzIDAgMCAwIDE1IDExIiBzdHJva2U9IiM5Q0EzQUYiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+Cjwvc3ZnPgo='
+              }}
+            />
+          </div>
+          <div className="space-y-2 text-sm">
+            {product.barcode && (
+              <p>
+                <span className="font-medium text-gray-700">Código de barras:</span>{' '}
+                {product.barcode}
+              </p>
+            )}
+            <p>
+              <span className="font-medium text-gray-700">Precio:</span>{' '}
+              {product.price.toLocaleString('es-CL', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0,
+              })}
+            </p>
+            <p>
+              <span className="font-medium text-gray-700">Stock:</span>{' '}
+              {product.stock}
+            </p>
+            {product.stock_minimum !== undefined && (
+              <p>
+                <span className="font-medium text-gray-700">Stock mínimo:</span>{' '}
+                {product.stock_minimum}
+              </p>
+            )}
+            {product.description && (
+              <p className="whitespace-pre-line">{product.description}</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ProductDetailModal
+

--- a/frontend/src/components/Ventas/ProductCard.jsx
+++ b/frontend/src/components/Ventas/ProductCard.jsx
@@ -1,5 +1,5 @@
 // src/components/ventas/ProductCard.jsx
-function ProductCard({ product, quantity, onQuantityChange, onAdd }) {
+function ProductCard({ product, quantity, onQuantityChange, onAdd, onShowDetails }) {
   const isOutOfStock = product.stock === 0
   const isBelowMinimum = product.stock < product.stock_minimum
 
@@ -33,9 +33,12 @@ function ProductCard({ product, quantity, onQuantityChange, onAdd }) {
 
       {/* Información del producto */}
       <div className="p-3">
-        <h3 className="font-medium text-sm text-gray-900 mb-2 line-clamp-2 min-h-[2.5rem]">
+        <h3 className="font-medium text-sm text-gray-900 mb-1 line-clamp-2 min-h-[2.5rem]">
           {product.name}
         </h3>
+        {product.barcode && (
+          <p className="text-xs text-gray-500 mb-1">Cod: {product.barcode}</p>
+        )}
         
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center space-x-1">
@@ -119,6 +122,14 @@ function ProductCard({ product, quantity, onQuantityChange, onAdd }) {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
             </svg>
             <span className="text-xs">Agregar</span>
+          </button>
+
+          <button
+            onClick={onShowDetails}
+            className="mt-2 text-xs text-blue-600 hover:underline"
+            type="button"
+          >
+            Ver detalles
           </button>
         </div>
 

--- a/frontend/src/components/Ventas/ProductRow.jsx
+++ b/frontend/src/components/Ventas/ProductRow.jsx
@@ -1,5 +1,5 @@
 // src/components/ventas/ProductRow.jsx
-function ProductRow({ product, quantity, onQuantityChange, onAdd }) {
+function ProductRow({ product, quantity, onQuantityChange, onAdd, onShowDetails }) {
   const isOutOfStock = product.stock === 0
   const isBelowMinimum = product.stock < product.stock_minimum
 
@@ -23,7 +23,10 @@ function ProductRow({ product, quantity, onQuantityChange, onAdd }) {
       </div>
       {/* Información */}
       <div className="flex-1 min-w-0">
-        <h3 className="font-medium text-sm text-gray-900 truncate">{product.name}</h3>
+        <h3 className="font-medium text-sm text-gray-900 truncate mb-0.5">{product.name}</h3>
+        {product.barcode && (
+          <p className="text-xs text-gray-500 truncate mb-1">Cod: {product.barcode}</p>
+        )}
         <div className="flex items-center space-x-2 text-xs">
           <span className="text-gray-500">Stock:</span>
           <span
@@ -93,6 +96,14 @@ function ProductRow({ product, quantity, onQuantityChange, onAdd }) {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
           </svg>
           <span className="text-xs">Agregar</span>
+        </button>
+
+        <button
+          onClick={onShowDetails}
+          className="text-xs text-blue-600 hover:underline"
+          type="button"
+        >
+          Ver detalles
         </button>
       </div>
     </div>

--- a/frontend/src/pages/Ventas.jsx
+++ b/frontend/src/pages/Ventas.jsx
@@ -4,6 +4,7 @@ import ProductCard from '@components/ventas/ProductCard.jsx'
 import ProductRow from '@components/ventas/ProductRow.jsx'
 import CartSummary from '@components/ventas/CartSummary.jsx'
 import Pagination from '@components/ventas/Pagination.jsx'
+import ProductDetailModal from '@components/ProductDetailModal.jsx'
 
 const PER_PAGE_GRID = 12
 const PER_PAGE_LIST = 15
@@ -18,6 +19,7 @@ function Ventas() {
   const [cart, setCart] = useState([])
   const [page, setPage] = useState(1)
   const [viewMode, setViewMode] = useState('grid')
+  const [detailProduct, setDetailProduct] = useState(null)
   const [saleInfo, setSaleInfo] = useState({
     client_first_name: '',
     client_last_name: '',
@@ -205,6 +207,7 @@ function Ventas() {
                           quantity={qtyMap[p.id] || 1}
                           onQuantityChange={(val) => handleQtyChange(p.id, val)}
                           onAdd={() => handleAdd(p)}
+                          onShowDetails={() => setDetailProduct(p)}
                         />
                       ))}
                     </div>
@@ -217,6 +220,7 @@ function Ventas() {
                           quantity={qtyMap[p.id] || 1}
                           onQuantityChange={(val) => handleQtyChange(p.id, val)}
                           onAdd={() => handleAdd(p)}
+                          onShowDetails={() => setDetailProduct(p)}
                         />
                       ))}
                     </div>
@@ -260,6 +264,11 @@ function Ventas() {
           </div>
         </div>
       </div>
+      <ProductDetailModal
+        open={!!detailProduct}
+        product={detailProduct}
+        onClose={() => setDetailProduct(null)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `ProductDetailModal` component
- show barcode on product cards, product list rows, and inventory rows
- display detail modal in sales page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6879348fbd30832cb679ca12ed02e386