### PR TITLE
Enable modal on image click

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -6,7 +6,7 @@ function Layout({ user, onLogout }) {
   return (
     <div className="flex h-screen">
       <Sidebar user={user} onLogout={onLogout} />
-      <main className="flex-1 bg-gray-100 overflow-y-auto">
+      <main className="flex-1 bg-gray-100">
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/Ventas/ProductCard.jsx
+++ b/frontend/src/components/Ventas/ProductCard.jsx
@@ -24,7 +24,8 @@ function ProductCard({ product, quantity, onQuantityChange, onAdd, onShowDetails
         <img
           src={product.image}
           alt={product.name}
-          className="max-h-full max-w-full object-contain transition-transform duration-300 group-hover:scale-105"
+          className="max-h-full max-w-full object-contain transition-transform duration-300 group-hover:scale-105 cursor-pointer"
+          onClick={onShowDetails}
           onError={(e) => {
             e.target.src = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTIwIDdMMTYgM0g4TDQgN1YxN0E0IDQgMCAwIDAgOCAyMUgxNkE0IDQgMCAwIDAgMjAgMTdWN1oiIHN0cm9rZT0iIzlDQTNBRiIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTkgMTFBMyAzIDAgMCAwIDE1IDExIiBzdHJva2U9IiM5Q0EzQUYiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+Cjwvc3ZnPgo='
           }}
@@ -124,13 +125,6 @@ function ProductCard({ product, quantity, onQuantityChange, onAdd, onShowDetails
             <span className="text-xs">Agregar</span>
           </button>
 
-          <button
-            onClick={onShowDetails}
-            className="mt-2 text-xs text-blue-600 hover:underline"
-            type="button"
-          >
-            Ver detalles
-          </button>
         </div>
 
         {/* Mensaje de validación */}

--- a/frontend/src/components/Ventas/ProductRow.jsx
+++ b/frontend/src/components/Ventas/ProductRow.jsx
@@ -14,7 +14,8 @@ function ProductRow({ product, quantity, onQuantityChange, onAdd, onShowDetails 
         <img
           src={product.image}
           alt={product.name}
-          className="max-h-full max-w-full object-contain"
+          className="max-h-full max-w-full object-contain cursor-pointer"
+          onClick={onShowDetails}
           onError={(e) => {
             e.target.src =
               'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTIwIDdMMTYgM0g4TDQgN1YxN0E0IDQgMCAwIDAgOCAyMUgxNkE0IDQgMCAwIDAgMjAgMTdWN1oiIHN0cm9rZT0iIzlDQTNBRiIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPHBhdGggZD0iTTkgMTFBMyAzIDAgMCAwIDE1IDExIiBzdHJva2U9IiM5Q0EzQUYiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+Cjwvc3ZnPgo='
@@ -98,13 +99,6 @@ function ProductRow({ product, quantity, onQuantityChange, onAdd, onShowDetails 
           <span className="text-xs">Agregar</span>
         </button>
 
-        <button
-          onClick={onShowDetails}
-          className="text-xs text-blue-600 hover:underline"
-          type="button"
-        >
-          Ver detalles
-        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- open product detail modal by clicking on product images
- remove "Ver detalles" buttons from product cards and rows
- remove custom scroll on the main layout

## Testing
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_687937feeaf0832c845a7bf6ed17954a