### PR TITLE
Add basic categories admin and report pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,10 @@ import Dashboard from './pages/Dashboard.jsx'
 import Inventario from './pages/Inventario.jsx'
 import Ventas from './pages/Ventas.jsx'
 import Reportes from './pages/Reportes.jsx'
+import Categorias from './pages/Categorias.jsx'
+import ReportesVentas from './pages/ReportesVentas.jsx'
+import ReportesInventario from './pages/ReportesInventario.jsx'
+import ReportesFinanciero from './pages/ReportesFinanciero.jsx'
 import Cotizaciones from './pages/Cotizaciones.jsx'
 
 function App() {
@@ -94,8 +98,12 @@ function App() {
         <Route element={<Layout user={user} onLogout={handleLogout} />}>
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/inventario" element={<Inventario />} />
+          <Route path="/inventario/categorias" element={<Categorias />} />
           <Route path="/ventas" element={<Ventas />} />
           <Route path="/reportes" element={<Reportes />} />
+          <Route path="/reportes/ventas" element={<ReportesVentas />} />
+          <Route path="/reportes/inventario" element={<ReportesInventario />} />
+          <Route path="/reportes/financiero" element={<ReportesFinanciero />} />
           <Route path="/cotizaciones" element={<Cotizaciones />} />
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Route>

--- a/frontend/src/components/Categorias/CategoryFormModal.jsx
+++ b/frontend/src/components/Categorias/CategoryFormModal.jsx
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from 'react'
+
+function CategoryFormModal({ open, onClose, onSave, category }) {
+  const [form, setForm] = useState({ name: '', description: '' })
+
+  useEffect(() => {
+    if (category) {
+      setForm({ name: category.name || '', description: category.description || '' })
+    } else {
+      setForm({ name: '', description: '' })
+    }
+  }, [category])
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    onSave(form)
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-sm p-6">
+        <h2 className="text-xl font-semibold mb-4">
+          {category ? 'Editar Categoría' : 'Nueva Categoría'}
+        </h2>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nombre</label>
+            <input
+              type="text"
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Descripción</label>
+            <textarea
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+              rows="3"
+            />
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 bg-gray-200 rounded-md">
+              Cancelar
+            </button>
+            <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-md">
+              Guardar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default CategoryFormModal

--- a/frontend/src/components/Categorias/CategoryRow.jsx
+++ b/frontend/src/components/Categorias/CategoryRow.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+function CategoryRow({ category, onEdit, onDelete }) {
+  return (
+    <div className="flex items-center justify-between p-3 bg-white rounded-lg shadow">
+      <div>
+        <p className="font-medium text-gray-800">{category.name}</p>
+        {category.description && (
+          <p className="text-sm text-gray-500">{category.description}</p>
+        )}
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={() => onEdit(category)}
+          className="px-3 py-1 text-xs text-white bg-blue-600 rounded hover:bg-blue-700"
+        >
+          Editar
+        </button>
+        <button
+          onClick={() => onDelete(category)}
+          className="px-3 py-1 text-xs text-white bg-red-600 rounded hover:bg-red-700"
+        >
+          Eliminar
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default CategoryRow

--- a/frontend/src/pages/Categorias.jsx
+++ b/frontend/src/pages/Categorias.jsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react'
+import CategoryRow from '@components/Categorias/CategoryRow.jsx'
+import CategoryFormModal from '@components/Categorias/CategoryFormModal.jsx'
+
+function Categorias() {
+  const [categories, setCategories] = useState([])
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editing, setEditing] = useState(null)
+  const token = localStorage.getItem('access')
+
+  const authHeaders = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+
+  const fetchCategories = () => {
+    fetch('http://192.168.1.52:8000/api/categories/', { headers: authHeaders })
+      .then((r) => r.json())
+      .then(setCategories)
+      .catch((e) => console.error(e))
+  }
+
+  useEffect(() => {
+    fetchCategories()
+  }, [])
+
+  const handleSave = async (data) => {
+    try {
+      const resp = await fetch(
+        editing ? `http://192.168.1.52:8000/api/categories/${editing.id}/` : 'http://192.168.1.52:8000/api/categories/',
+        {
+          method: editing ? 'PUT' : 'POST',
+          headers: authHeaders,
+          body: JSON.stringify(data),
+        }
+      )
+      if (!resp.ok) throw new Error('Error al guardar')
+      setModalOpen(false)
+      setEditing(null)
+      fetchCategories()
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  const handleDelete = async (cat) => {
+    if (!window.confirm('¿Eliminar categoría?')) return
+    try {
+      const resp = await fetch(`http://192.168.1.52:8000/api/categories/${cat.id}/`, {
+        method: 'DELETE',
+        headers: authHeaders,
+      })
+      if (!resp.ok) throw new Error('Error al eliminar')
+      fetchCategories()
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-4 h-full bg-gray-50">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-800">Categorías</h2>
+        <button
+          onClick={() => {
+            setEditing(null)
+            setModalOpen(true)
+          }}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Nueva Categoría
+        </button>
+      </div>
+
+      <div className="space-y-2 overflow-y-auto" style={{ maxHeight: 'calc(100vh - 160px)' }}>
+        {categories.map((cat) => (
+          <CategoryRow key={cat.id} category={cat} onEdit={(c) => { setEditing(c); setModalOpen(true) }} onDelete={handleDelete} />
+        ))}
+      </div>
+
+      <CategoryFormModal
+        open={modalOpen}
+        onClose={() => { setModalOpen(false); setEditing(null) }}
+        onSave={handleSave}
+        category={editing}
+      />
+    </div>
+  )
+}
+
+export default Categorias

--- a/frontend/src/pages/ReportesFinanciero.jsx
+++ b/frontend/src/pages/ReportesFinanciero.jsx
@@ -1,0 +1,10 @@
+function ReportesFinanciero() {
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-bold mb-4">Reporte Financiero</h2>
+      <p className="text-gray-700">Sección para reportes financieros.</p>
+    </div>
+  )
+}
+
+export default ReportesFinanciero

--- a/frontend/src/pages/ReportesInventario.jsx
+++ b/frontend/src/pages/ReportesInventario.jsx
@@ -1,0 +1,10 @@
+function ReportesInventario() {
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-bold mb-4">Reporte de Inventario</h2>
+      <p className="text-gray-700">Sección para reportes detallados de inventario.</p>
+    </div>
+  )
+}
+
+export default ReportesInventario

--- a/frontend/src/pages/ReportesVentas.jsx
+++ b/frontend/src/pages/ReportesVentas.jsx
@@ -1,0 +1,10 @@
+function ReportesVentas() {
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-bold mb-4">Reporte de Ventas</h2>
+      <p className="text-gray-700">Sección para reportes detallados de ventas.</p>
+    </div>
+  )
+}
+
+export default ReportesVentas


### PR DESCRIPTION
## Summary
- implement categories admin page with add/edit/delete
- create components `CategoryRow` and `CategoryFormModal`
- add placeholder pages for sales, inventory and financial reports
- register new routes including `/inventario/categorias` and report routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python Backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687d5b5c3b98832c92af9a4dc11fd9e2