### PR TITLE
Add inventory dashboard and products page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Login from './pages/Login.jsx'
 import Layout from './components/Layout.jsx'
 import Dashboard from './pages/Dashboard.jsx'
 import Inventario from './pages/Inventario.jsx'
+import Productos from './pages/Productos.jsx'
 import Ventas from './pages/Ventas.jsx'
 import Reportes from './pages/Reportes.jsx'
 import Categorias from './pages/Categorias.jsx'
@@ -98,6 +99,7 @@ function App() {
         <Route element={<Layout user={user} onLogout={handleLogout} />}>
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/inventario" element={<Inventario />} />
+          <Route path="/inventario/productos" element={<Productos />} />
           <Route path="/inventario/categorias" element={<Categorias />} />
           <Route path="/ventas" element={<Ventas />} />
           <Route path="/reportes" element={<Reportes />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -40,8 +40,8 @@ function Sidebar({ user, onLogout }) {
         </svg>
       )
     },
-    { 
-      to: '/inventario', 
+    {
+      to: '/inventario',
       label: 'Inventario',
       icon: (
         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -49,17 +49,27 @@ function Sidebar({ user, onLogout }) {
         </svg>
       ),
       submenus: [
-        { 
-          to: '/inventario', 
-          label: 'Productos',
+        {
+          to: '/inventario',
+          label: 'Dashboard',
           icon: (
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10" />
             </svg>
           )
         },
-        { 
-          to: '/inventario/categorias', 
+        {
+          to: '/inventario/productos',
+          label: 'Productos',
+          icon: (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+            </svg>
+          )
+        }
+        ,
+        {
+          to: '/inventario/categorias',
           label: 'Categorías',
           icon: (
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/pages/Inventario.jsx
+++ b/frontend/src/pages/Inventario.jsx
@@ -1,21 +1,14 @@
 import { useState, useEffect } from 'react'
-import InventoryRow from '@components/Inventario/InventoryRow.jsx'
-import ProductFormModal from '@components/Inventario/ProductFormModal.jsx'
+import { Link } from 'react-router-dom'
 
 function Inventario() {
+  const [sales, setSales] = useState([])
   const [products, setProducts] = useState([])
-  const [categories, setCategories] = useState([])
-  const [query, setQuery] = useState('')
-  const [categoryFilter, setCategoryFilter] = useState('')
-  const [onlyLow, setOnlyLow] = useState(false)
-  const [editing, setEditing] = useState(null)
-  const [modalOpen, setModalOpen] = useState(false)
-  const [loading, setLoading] = useState(true)
-
+  const [selectedSale, setSelectedSale] = useState(null)
   const token = localStorage.getItem('access')
   const authHeaders = { Authorization: `Bearer ${token}` }
 
-  const fetchAllProducts = async (url) => {
+  const fetchAll = async (url) => {
     const items = []
     let next = url
     while (next) {
@@ -25,279 +18,156 @@ function Inventario() {
         items.push(...data)
         break
       }
-      if (data.results) {
-        items.push(...data.results)
-        next = data.next
-      } else {
-        items.push(...data)
-        next = null
-      }
+      items.push(...(data.results || []))
+      next = data.next
     }
     return items
   }
 
   const fetchData = () => {
-    setLoading(true)
     Promise.all([
-      fetchAllProducts('http://192.168.1.52:8000/api/products/'),
-      fetch('http://192.168.1.52:8000/api/categories/', {
-        headers: authHeaders,
-      }).then((r) => r.json()),
+      fetchAll('http://192.168.1.52:8000/api/sales/'),
+      fetchAll('http://192.168.1.52:8000/api/products/'),
     ])
-      .then(([prods, cats]) => {
-        setProducts(prods)
-        setCategories(cats)
+      .then(([salesData, productsData]) => {
+        setSales(salesData)
+        setProducts(productsData)
       })
       .catch((e) => console.error(e))
-      .finally(() => setLoading(false))
   }
 
   useEffect(() => {
     fetchData()
   }, [])
 
-  const filtered = products.filter(
-    (p) =>
-      p.name.toLowerCase().includes(query.toLowerCase()) &&
-      (categoryFilter === '' || p.category === parseInt(categoryFilter)) &&
-      (!onlyLow || p.stock <= p.stock_minimum)
-  )
-
-  const handleSave = async (data) => {
-    try {
-      const resp = await fetch(
-        editing
-          ? `http://192.168.1.52:8000/api/products/${editing.id}/`
-          : 'http://192.168.1.52:8000/api/products/',
-        {
-          method: editing ? 'PUT' : 'POST',
-          headers: authHeaders,
-          body: data,
-        }
-      )
-      if (!resp.ok) throw new Error('Error al guardar')
-      setModalOpen(false)
-      setEditing(null)
-      fetchData()
-    } catch (err) {
-      alert(err.message)
-    }
-  }
-
-  const handleDelete = async (product) => {
-    if (!window.confirm('¿Eliminar producto?')) return
-    try {
-      const resp = await fetch(
-        `http://192.168.1.52:8000/api/products/${product.id}/`,
-        { method: 'DELETE', headers: authHeaders }
-      )
-      if (!resp.ok) throw new Error('Error al eliminar')
-      fetchData()
-    } catch (err) {
-      alert(err.message)
-    }
-  }
-
-  const lowStockCount = products.filter(p => p.stock <= p.stock_minimum).length
+  const productMap = Object.fromEntries(products.map((p) => [p.id, p]))
+  const productSales = {}
+  sales.forEach((s) => {
+    s.details.forEach((d) => {
+      productSales[d.product_id] = (productSales[d.product_id] || 0) + d.quantity
+    })
+  })
+  const topProducts = Object.entries(productSales)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([id, qty]) => ({ id: parseInt(id), qty, name: productMap[id]?.name }))
 
   return (
-    <div className="h-screen bg-gradient-to-br from-slate-50 to-blue-50 p-4 overflow-hidden">
-      {/* Contenedor principal con altura de viewport completa */}
-      <div className="h-full max-w-full mx-auto">
-        {/* Contenedor principal del inventario */}
-        <div className="h-full flex flex-col">
-          
-          {/* Sección principal de inventario */}
-          <div className="flex-1 min-h-0">
-            <div className="bg-white rounded-xl shadow-lg h-full flex flex-col overflow-hidden">
-              
-              {/* Header con título y estadísticas - altura fija */}
-              <div className="flex-shrink-0 p-4 border-b border-gray-100">
-                <div className="flex items-center justify-between mb-4">
-                  <div>
-                    <h1 className="text-2xl font-bold text-gray-800">Inventario</h1>
-                    <p className="text-gray-600 text-sm mt-1">Gestión de productos y stock</p>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <div className="bg-blue-50 px-3 py-2 rounded-lg">
-                      <span className="text-xs text-blue-600">Total: </span>
-                      <span className="font-semibold text-blue-700">{products.length}</span>
-                    </div>
-                    {lowStockCount > 0 && (
-                      <div className="bg-red-50 px-3 py-2 rounded-lg">
-                        <span className="text-xs text-red-600">Stock bajo: </span>
-                        <span className="font-semibold text-red-700">{lowStockCount}</span>
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                {/* Filtros y Búsqueda */}
-                <div className="flex flex-col lg:flex-row gap-3 mb-3">
-                  {/* Búsqueda */}
-                  <div className="flex-2">
-                    <label className="block text-xs font-medium text-gray-700 mb-1">
-                      Buscar producto
-                    </label>
-                    <div className="relative">
-                      <input
-                        type="text"
-                        placeholder="Buscar por nombre..."
-                        className="w-full px-3 py-2 pl-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 shadow-sm text-sm"
-                        value={query}
-                        onChange={(e) => setQuery(e.target.value)}
-                      />
-                      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                        <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Selector de categoría */}
-                  <div className="flex-1">
-                    <label className="block text-xs font-medium text-gray-700 mb-1">
-                      Categoría
-                    </label>
-                    <select
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 shadow-sm text-sm"
-                      value={categoryFilter}
-                      onChange={(e) => setCategoryFilter(e.target.value)}
-                    >
-                      <option value="">Todas las categorías</option>
-                      {categories.map((c) => (
-                        <option key={c.id} value={c.id}>
-                          {c.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-
-                  {/* Checkbox y botón */}
-                  <div className="flex items-end gap-2">
-                    <div className="flex items-center h-[34px] px-3 bg-gray-50 rounded-lg border border-gray-300">
-                      <input
-                        id="low"
-                        type="checkbox"
-                        checked={onlyLow}
-                        onChange={(e) => setOnlyLow(e.target.checked)}
-                        className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
-                      />
-                      <label htmlFor="low" className="ml-2 text-xs font-medium text-gray-700">
-                        Stock bajo
-                      </label>
-                    </div>
-                    
-                    <button
-                      onClick={() => {
-                        setEditing(null)
-                        setModalOpen(true)
-                      }}
-                      className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-all duration-200 shadow-sm text-sm h-[34px]"
-                    >
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                      </svg>
-                      Nuevo
-                    </button>
-                  </div>
-                </div>
-
-                {/* Barra de herramientas */}
-                <div className="flex items-center justify-between text-xs text-gray-600">
-                  <span>
-                    {filtered.length} producto{filtered.length !== 1 ? 's' : ''} encontrado{filtered.length !== 1 ? 's' : ''}
-                  </span>
-                  {(query || categoryFilter || onlyLow) && (
-                    <button
-                      onClick={() => {
-                        setQuery('')
-                        setCategoryFilter('')
-                        setOnlyLow(false)
-                      }}
-                      className="text-blue-600 hover:text-blue-700 font-medium"
-                    >
-                      Limpiar filtros
-                    </button>
-                  )}
-                </div>
-              </div>
-              
-              {/* Área de productos - altura flexible con scroll */}
-              <div className="flex-1 min-h-0 p-4 pt-3">
-                {loading ? (
-                  <div className="h-full flex flex-col items-center justify-center text-center">
-                    <div className="flex items-center gap-3 text-gray-600">
-                      <svg className="animate-spin w-6 h-6 text-blue-600" fill="none" viewBox="0 0 24 24">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                      </svg>
-                      <span>Cargando productos...</span>
-                    </div>
-                  </div>
-                ) : filtered.length > 0 ? (
-                  <div className="h-full overflow-y-auto">
-                    <div className="space-y-2 pb-2">
-                      {filtered.map((p) => (
-                        <InventoryRow
-                          key={p.id}
-                          product={p}
-                          onEdit={(prod) => {
-                            setEditing(prod)
-                            setModalOpen(true)
-                          }}
-                          onDelete={handleDelete}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                ) : (
-                  <div className="h-full flex flex-col items-center justify-center text-center">
-                    <div className="text-gray-400 mb-3">
-                      <svg className="h-12 w-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
-                      </svg>
-                    </div>
-                    <p className="text-gray-500 text-base mb-2">No se encontraron productos</p>
-                    <p className="text-gray-400 text-xs mb-4">
-                      {query || categoryFilter || onlyLow 
-                        ? 'Intenta ajustar los filtros de búsqueda' 
-                        : 'Comienza agregando tu primer producto'}
-                    </p>
-                    {!query && !categoryFilter && !onlyLow && (
-                      <button
-                        onClick={() => {
-                          setEditing(null)
-                          setModalOpen(true)
-                        }}
-                        className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors duration-200 text-sm"
-                      >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                        </svg>
-                        Agregar producto
-                      </button>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-800">Inventario</h2>
+        <div className="space-x-2">
+          <Link
+            to="/inventario/productos"
+            className="px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+          >
+            Productos
+          </Link>
+          <Link
+            to="/inventario/categorias"
+            className="px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+          >
+            Categorías
+          </Link>
         </div>
       </div>
 
-      {/* Modal */}
-      <ProductFormModal
-        open={modalOpen}
-        onClose={() => {
-          setModalOpen(false)
-          setEditing(null)
-        }}
-        onSave={handleSave}
-        product={editing}
-        categories={categories}
-      />
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="bg-white rounded-lg shadow p-4">
+          <h3 className="text-lg font-semibold mb-3">Productos más vendidos</h3>
+          {topProducts.length > 0 ? (
+            <ul className="space-y-2">
+              {topProducts.map((p) => (
+                <li key={p.id} className="flex justify-between text-sm">
+                  <span>{p.name || `Producto ${p.id}`}</span>
+                  <span className="font-medium">{p.qty}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-500">No hay datos</p>
+          )}
+        </div>
+
+        <div className="bg-white rounded-lg shadow p-4 md:row-span-2">
+          <h3 className="text-lg font-semibold mb-3">Ventas registradas</h3>
+          {sales.length > 0 ? (
+            <div className="space-y-2 max-h-80 overflow-y-auto">
+              {sales.map((s) => (
+                <div
+                  key={s.id}
+                  className="p-3 bg-gray-50 rounded-lg hover:bg-gray-100 cursor-pointer flex justify-between items-center"
+                  onClick={() => setSelectedSale(s)}
+                >
+                  <div>
+                    <p className="font-medium text-gray-800">Venta #{s.id}</p>
+                    <p className="text-xs text-gray-500">
+                      {new Date(s.sale_date).toLocaleString()}
+                    </p>
+                  </div>
+                  <div className="font-bold text-gray-800">
+                    {parseFloat(s.total).toLocaleString('es-CL', {
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 0,
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500">No hay ventas registradas</p>
+          )}
+        </div>
+      </div>
+
+      {selectedSale && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-lg w-full max-w-lg p-6">
+            <div className="flex justify-between mb-4">
+              <h3 className="text-lg font-semibold">
+                Venta #{selectedSale.id}
+              </h3>
+              <button
+                onClick={() => setSelectedSale(null)}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                &#10005;
+              </button>
+            </div>
+            <div className="space-y-2 text-sm">
+              <p>
+                <span className="font-medium">Cliente:</span>{' '}
+                {selectedSale.client_first_name} {selectedSale.client_last_name}
+              </p>
+              <p>
+                <span className="font-medium">RUT:</span> {selectedSale.client_rut}
+              </p>
+              <p>
+                <span className="font-medium">Fecha:</span>{' '}
+                {new Date(selectedSale.sale_date).toLocaleString()}
+              </p>
+              <p>
+                <span className="font-medium">Total:</span>{' '}
+                {parseFloat(selectedSale.total).toLocaleString('es-CL', {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 0,
+                })}
+              </p>
+            </div>
+            <div className="mt-4">
+              <h4 className="font-medium text-gray-800 mb-2">Detalles</h4>
+              <ul className="space-y-1 max-h-60 overflow-y-auto text-sm">
+                {selectedSale.details.map((d, i) => (
+                  <li key={i} className="flex justify-between">
+                    <span>{productMap[d.product_id]?.name || `Producto ${d.product_id}`}</span>
+                    <span className="text-gray-700">x{d.quantity}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/Productos.jsx
+++ b/frontend/src/pages/Productos.jsx
@@ -1,0 +1,305 @@
+import { useState, useEffect } from 'react'
+import InventoryRow from '@components/Inventario/InventoryRow.jsx'
+import ProductFormModal from '@components/Inventario/ProductFormModal.jsx'
+
+function Productos() {
+  const [products, setProducts] = useState([])
+  const [categories, setCategories] = useState([])
+  const [query, setQuery] = useState('')
+  const [categoryFilter, setCategoryFilter] = useState('')
+  const [onlyLow, setOnlyLow] = useState(false)
+  const [editing, setEditing] = useState(null)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  const token = localStorage.getItem('access')
+  const authHeaders = { Authorization: `Bearer ${token}` }
+
+  const fetchAllProducts = async (url) => {
+    const items = []
+    let next = url
+    while (next) {
+      const resp = await fetch(next, { headers: authHeaders })
+      const data = await resp.json()
+      if (Array.isArray(data)) {
+        items.push(...data)
+        break
+      }
+      if (data.results) {
+        items.push(...data.results)
+        next = data.next
+      } else {
+        items.push(...data)
+        next = null
+      }
+    }
+    return items
+  }
+
+  const fetchData = () => {
+    setLoading(true)
+    Promise.all([
+      fetchAllProducts('http://192.168.1.52:8000/api/products/'),
+      fetch('http://192.168.1.52:8000/api/categories/', {
+        headers: authHeaders,
+      }).then((r) => r.json()),
+    ])
+      .then(([prods, cats]) => {
+        setProducts(prods)
+        setCategories(cats)
+      })
+      .catch((e) => console.error(e))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  const filtered = products.filter(
+    (p) =>
+      p.name.toLowerCase().includes(query.toLowerCase()) &&
+      (categoryFilter === '' || p.category === parseInt(categoryFilter)) &&
+      (!onlyLow || p.stock <= p.stock_minimum)
+  )
+
+  const handleSave = async (data) => {
+    try {
+      const resp = await fetch(
+        editing
+          ? `http://192.168.1.52:8000/api/products/${editing.id}/`
+          : 'http://192.168.1.52:8000/api/products/',
+        {
+          method: editing ? 'PUT' : 'POST',
+          headers: authHeaders,
+          body: data,
+        }
+      )
+      if (!resp.ok) throw new Error('Error al guardar')
+      setModalOpen(false)
+      setEditing(null)
+      fetchData()
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  const handleDelete = async (product) => {
+    if (!window.confirm('¿Eliminar producto?')) return
+    try {
+      const resp = await fetch(
+        `http://192.168.1.52:8000/api/products/${product.id}/`,
+        { method: 'DELETE', headers: authHeaders }
+      )
+      if (!resp.ok) throw new Error('Error al eliminar')
+      fetchData()
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  const lowStockCount = products.filter(p => p.stock <= p.stock_minimum).length
+
+  return (
+    <div className="h-screen bg-gradient-to-br from-slate-50 to-blue-50 p-4 overflow-hidden">
+      {/* Contenedor principal con altura de viewport completa */}
+      <div className="h-full max-w-full mx-auto">
+        {/* Contenedor principal del inventario */}
+        <div className="h-full flex flex-col">
+          
+          {/* Sección principal de inventario */}
+          <div className="flex-1 min-h-0">
+            <div className="bg-white rounded-xl shadow-lg h-full flex flex-col overflow-hidden">
+              
+              {/* Header con título y estadísticas - altura fija */}
+              <div className="flex-shrink-0 p-4 border-b border-gray-100">
+                <div className="flex items-center justify-between mb-4">
+                  <div>
+                    <h1 className="text-2xl font-bold text-gray-800">Inventario</h1>
+                    <p className="text-gray-600 text-sm mt-1">Gestión de productos y stock</p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <div className="bg-blue-50 px-3 py-2 rounded-lg">
+                      <span className="text-xs text-blue-600">Total: </span>
+                      <span className="font-semibold text-blue-700">{products.length}</span>
+                    </div>
+                    {lowStockCount > 0 && (
+                      <div className="bg-red-50 px-3 py-2 rounded-lg">
+                        <span className="text-xs text-red-600">Stock bajo: </span>
+                        <span className="font-semibold text-red-700">{lowStockCount}</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Filtros y Búsqueda */}
+                <div className="flex flex-col lg:flex-row gap-3 mb-3">
+                  {/* Búsqueda */}
+                  <div className="flex-2">
+                    <label className="block text-xs font-medium text-gray-700 mb-1">
+                      Buscar producto
+                    </label>
+                    <div className="relative">
+                      <input
+                        type="text"
+                        placeholder="Buscar por nombre..."
+                        className="w-full px-3 py-2 pl-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 shadow-sm text-sm"
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                      />
+                      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                        <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Selector de categoría */}
+                  <div className="flex-1">
+                    <label className="block text-xs font-medium text-gray-700 mb-1">
+                      Categoría
+                    </label>
+                    <select
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 shadow-sm text-sm"
+                      value={categoryFilter}
+                      onChange={(e) => setCategoryFilter(e.target.value)}
+                    >
+                      <option value="">Todas las categorías</option>
+                      {categories.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {/* Checkbox y botón */}
+                  <div className="flex items-end gap-2">
+                    <div className="flex items-center h-[34px] px-3 bg-gray-50 rounded-lg border border-gray-300">
+                      <input
+                        id="low"
+                        type="checkbox"
+                        checked={onlyLow}
+                        onChange={(e) => setOnlyLow(e.target.checked)}
+                        className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                      />
+                      <label htmlFor="low" className="ml-2 text-xs font-medium text-gray-700">
+                        Stock bajo
+                      </label>
+                    </div>
+                    
+                    <button
+                      onClick={() => {
+                        setEditing(null)
+                        setModalOpen(true)
+                      }}
+                      className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-all duration-200 shadow-sm text-sm h-[34px]"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                      </svg>
+                      Nuevo
+                    </button>
+                  </div>
+                </div>
+
+                {/* Barra de herramientas */}
+                <div className="flex items-center justify-between text-xs text-gray-600">
+                  <span>
+                    {filtered.length} producto{filtered.length !== 1 ? 's' : ''} encontrado{filtered.length !== 1 ? 's' : ''}
+                  </span>
+                  {(query || categoryFilter || onlyLow) && (
+                    <button
+                      onClick={() => {
+                        setQuery('')
+                        setCategoryFilter('')
+                        setOnlyLow(false)
+                      }}
+                      className="text-blue-600 hover:text-blue-700 font-medium"
+                    >
+                      Limpiar filtros
+                    </button>
+                  )}
+                </div>
+              </div>
+              
+              {/* Área de productos - altura flexible con scroll */}
+              <div className="flex-1 min-h-0 p-4 pt-3">
+                {loading ? (
+                  <div className="h-full flex flex-col items-center justify-center text-center">
+                    <div className="flex items-center gap-3 text-gray-600">
+                      <svg className="animate-spin w-6 h-6 text-blue-600" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                      </svg>
+                      <span>Cargando productos...</span>
+                    </div>
+                  </div>
+                ) : filtered.length > 0 ? (
+                  <div className="h-full overflow-y-auto">
+                    <div className="space-y-2 pb-2">
+                      {filtered.map((p) => (
+                        <InventoryRow
+                          key={p.id}
+                          product={p}
+                          onEdit={(prod) => {
+                            setEditing(prod)
+                            setModalOpen(true)
+                          }}
+                          onDelete={handleDelete}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="h-full flex flex-col items-center justify-center text-center">
+                    <div className="text-gray-400 mb-3">
+                      <svg className="h-12 w-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+                      </svg>
+                    </div>
+                    <p className="text-gray-500 text-base mb-2">No se encontraron productos</p>
+                    <p className="text-gray-400 text-xs mb-4">
+                      {query || categoryFilter || onlyLow 
+                        ? 'Intenta ajustar los filtros de búsqueda' 
+                        : 'Comienza agregando tu primer producto'}
+                    </p>
+                    {!query && !categoryFilter && !onlyLow && (
+                      <button
+                        onClick={() => {
+                          setEditing(null)
+                          setModalOpen(true)
+                        }}
+                        className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors duration-200 text-sm"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                        </svg>
+                        Agregar producto
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Modal */}
+      <ProductFormModal
+        open={modalOpen}
+        onClose={() => {
+          setModalOpen(false)
+          setEditing(null)
+        }}
+        onSave={handleSave}
+        product={editing}
+        categories={categories}
+      />
+    </div>
+  )
+}
+
+export default Productos


### PR DESCRIPTION
## Summary
- add `/inventario/productos` page
- use the old inventory code for the products list
- build a new inventory dashboard displaying top products and sales with modal detail
- update routes and sidebar items

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687d619ce970832cbe949a38b8340682