### PR TITLE
Add cost/barcode fields and product details for quotes

### DIFF
--- a/frontend/src/components/Inventario/ProductFormModal.jsx
+++ b/frontend/src/components/Inventario/ProductFormModal.jsx
@@ -5,6 +5,8 @@ function ProductFormModal({ open, onClose, onSave, product, categories }) {
   const [form, setForm] = useState({
     name: '',
     price: 0,
+    cost: 0,
+    barcode: '',
     stock: 0,
     stock_minimum: 0,
     category: '',
@@ -16,6 +18,8 @@ function ProductFormModal({ open, onClose, onSave, product, categories }) {
       setForm({
         name: product.name || '',
         price: product.price || 0,
+        cost: product.cost || 0,
+        barcode: product.barcode || '',
         stock: product.stock || 0,
         stock_minimum: product.stock_minimum || 0,
         category: product.category || '',
@@ -25,6 +29,8 @@ function ProductFormModal({ open, onClose, onSave, product, categories }) {
       setForm({
         name: '',
         price: 0,
+        cost: 0,
+        barcode: '',
         stock: 0,
         stock_minimum: 0,
         category: '',
@@ -47,6 +53,8 @@ function ProductFormModal({ open, onClose, onSave, product, categories }) {
     const data = new FormData()
     data.append('name', form.name)
     data.append('price', form.price)
+    data.append('cost', form.cost)
+    data.append('barcode', form.barcode)
     data.append('stock', form.stock)
     data.append('stock_minimum', form.stock_minimum)
     data.append('category', form.category)
@@ -83,6 +91,26 @@ function ProductFormModal({ open, onClose, onSave, product, categories }) {
               onChange={handleChange}
               className="w-full border border-gray-300 rounded-md px-3 py-2"
               required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Costo</label>
+            <input
+              type="number"
+              name="cost"
+              value={form.cost}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Código de barras</label>
+            <input
+              type="text"
+              name="barcode"
+              value={form.barcode}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
             />
           </div>
           <div className="grid grid-cols-2 gap-2">

--- a/frontend/src/pages/Cotizaciones.jsx
+++ b/frontend/src/pages/Cotizaciones.jsx
@@ -3,6 +3,7 @@ import ProductCard from '@components/Ventas/ProductCard.jsx'
 import ProductRow from '@components/Ventas/ProductRow.jsx'
 import Pagination from '@components/Ventas/Pagination.jsx'
 import QuoteSummary from '@components/Cotizaciones/QuoteSummary.jsx'
+import ProductDetailModal from '@components/ProductDetailModal.jsx'
 
 const PER_PAGE_GRID = 12
 const PER_PAGE_LIST = 15
@@ -16,6 +17,7 @@ function Cotizaciones() {
   const [cart, setCart] = useState([])
   const [page, setPage] = useState(1)
   const [viewMode, setViewMode] = useState('grid')
+  const [detailProduct, setDetailProduct] = useState(null)
   const [quoteInfo, setQuoteInfo] = useState({
     client_name: '',
     client_rut: '',
@@ -270,6 +272,7 @@ function Cotizaciones() {
                             quantity={qtyMap[p.id] || 1}
                             onQuantityChange={(val) => handleQtyChange(p.id, val)}
                             onAdd={() => handleAdd(p)}
+                            onShowDetails={() => setDetailProduct(p)}
                           />
                         ))}
                       </div>
@@ -284,6 +287,7 @@ function Cotizaciones() {
                             quantity={qtyMap[p.id] || 1}
                             onQuantityChange={(val) => handleQtyChange(p.id, val)}
                             onAdd={() => handleAdd(p)}
+                            onShowDetails={() => setDetailProduct(p)}
                           />
                         ))}
                       </div>
@@ -455,6 +459,13 @@ function Cotizaciones() {
           </div>
         </div>
       )}
+
+      {/* Modal de detalles */}
+      <ProductDetailModal
+        open={!!detailProduct}
+        product={detailProduct}
+        onClose={() => setDetailProduct(null)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- allow managing cost and barcode in the inventory product form
- open product detail modal from quotes page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687d8c50fea4832c9b922300990cccf3