### PR TITLE
Add user management page and roles

### DIFF
--- a/Backend/users/serializers.py
+++ b/Backend/users/serializers.py
@@ -4,24 +4,51 @@ from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 
 class UserSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True, required=False)
+
     class Meta:
         model = User
-        fields = ['id', 'username', 'email', 'role', 'is_active']
+        fields = ['id', 'username', 'email', 'role', 'is_active', 'password']
+        extra_kwargs = {
+            'password': {'write_only': True}
+        }
+
+    def create(self, validated_data):
+        password = validated_data.pop('password', None)
+        user = User(**validated_data)
+        if password:
+            user.set_password(password)
+        user.save()
+        return user
+
+    def update(self, instance, validated_data):
+        password = validated_data.pop('password', None)
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        if password:
+            instance.set_password(password)
+        instance.save()
+        return instance
 
 
 class UserRegistrationSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True)
+    role = serializers.CharField(default='recepcionist')
 
     class Meta:
         model = User
-        fields = ['id', 'username', 'email', 'password']
+        fields = ['id', 'username', 'email', 'password', 'role']
 
     def create(self, validated_data):
-        return User.objects.create_user(
+        role = validated_data.pop('role', 'recepcionist')
+        user = User.objects.create_user(
             username=validated_data['username'],
             email=validated_data.get('email'),
             password=validated_data['password']
         )
+        user.role = role
+        user.save()
+        return user
 
 
 class UserLoginSerializer(TokenObtainPairSerializer):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import ReportesVentas from './pages/ReportesVentas.jsx'
 import ReportesInventario from './pages/ReportesInventario.jsx'
 import ReportesFinanciero from './pages/ReportesFinanciero.jsx'
 import Cotizaciones from './pages/Cotizaciones.jsx'
+import Usuarios from './pages/Usuarios.jsx'
 
 function App() {
   const [user, setUser] = useState(null)
@@ -104,10 +105,11 @@ function App() {
           <Route path="/ventas" element={<Ventas />} />
           <Route path="/reportes" element={<Reportes />} />
           <Route path="/reportes/ventas" element={<ReportesVentas />} />
-          <Route path="/reportes/inventario" element={<ReportesInventario />} />
-          <Route path="/reportes/financiero" element={<ReportesFinanciero />} />
-          <Route path="/cotizaciones" element={<Cotizaciones />} />
-          <Route path="*" element={<Navigate to="/dashboard" replace />} />
+        <Route path="/reportes/inventario" element={<ReportesInventario />} />
+        <Route path="/reportes/financiero" element={<ReportesFinanciero />} />
+        <Route path="/cotizaciones" element={<Cotizaciones />} />
+        <Route path="/usuarios" element={<Usuarios />} />
+        <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -29,7 +29,7 @@ function Sidebar({ user, onLogout }) {
     return link.submenus.some(submenu => location.pathname === submenu.to)
   }
 
-  const links = [
+  const baseLinks = [
     { 
       to: '/dashboard', 
       label: 'Dashboard',
@@ -126,6 +126,19 @@ function Sidebar({ user, onLogout }) {
       )
     },
   ]
+
+  const links = [...baseLinks]
+  if (user?.role === 'admin') {
+    links.push({
+      to: '/usuarios',
+      label: 'Usuarios',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        </svg>
+      )
+    })
+  }
 
   const toggleSubmenu = (index, e) => {
     // Solo prevenir navegación si se hace click en la flecha
@@ -245,7 +258,9 @@ function Sidebar({ user, onLogout }) {
             <p className="text-sm font-medium text-slate-200 truncate">
               {user?.username || 'Usuario'}
             </p>
-            <p className="text-xs text-slate-400">Administrador</p>
+            <p className="text-xs text-slate-400">
+              {user?.role === 'admin' ? 'Administrador' : 'Recepcionista'}
+            </p>
           </div>
         </div>
         

--- a/frontend/src/components/Usuarios/UserFormModal.jsx
+++ b/frontend/src/components/Usuarios/UserFormModal.jsx
@@ -1,0 +1,132 @@
+import { useState, useEffect } from 'react'
+
+function UserFormModal({ open, onClose, onSave, user }) {
+  const [form, setForm] = useState({
+    username: '',
+    email: '',
+    password: '',
+    role: 'recepcionist',
+    is_active: true,
+  })
+
+  useEffect(() => {
+    if (user) {
+      setForm({
+        username: user.username || '',
+        email: user.email || '',
+        password: '',
+        role: user.role || 'recepcionist',
+        is_active: user.is_active,
+      })
+    } else {
+      setForm({ username: '', email: '', password: '', role: 'recepcionist', is_active: true })
+    }
+  }, [user])
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target
+    setForm((prev) => ({ ...prev, [name]: type === 'checkbox' ? checked : value }))
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    const data = {
+      username: form.username,
+      email: form.email,
+      role: form.role,
+      is_active: form.is_active,
+    }
+    if (form.password) data.password = form.password
+    onSave(data)
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-sm flex flex-col overflow-hidden">
+        <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4 flex justify-between items-center">
+          <h2 className="text-xl font-semibold">{user ? 'Editar Usuario' : 'Nuevo Usuario'}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="bg-white/10 hover:bg-white/20 text-white rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 flex items-center gap-2"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            Cerrar
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-3 p-6 overflow-y-auto">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Usuario</label>
+            <input
+              type="text"
+              name="username"
+              value={form.username}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Correo</label>
+            <input
+              type="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Contraseña</label>
+            <input
+              type="password"
+              name="password"
+              value={form.password}
+              onChange={handleChange}
+              placeholder={user ? 'Dejar en blanco para mantener' : ''}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Rol</label>
+            <select
+              name="role"
+              value={form.role}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+            >
+              <option value="admin">Administrador</option>
+              <option value="recepcionist">Recepcionista</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="is_active"
+              name="is_active"
+              checked={form.is_active}
+              onChange={handleChange}
+            />
+            <label htmlFor="is_active" className="text-sm text-gray-700">
+              Activo
+            </label>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 bg-gray-200 rounded-md">
+              Cancelar
+            </button>
+            <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-md">
+              Guardar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default UserFormModal

--- a/frontend/src/pages/Usuarios.jsx
+++ b/frontend/src/pages/Usuarios.jsx
@@ -1,0 +1,112 @@
+import { useState, useEffect } from 'react'
+import UserFormModal from '@components/Usuarios/UserFormModal.jsx'
+
+function Usuarios() {
+  const [users, setUsers] = useState([])
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editing, setEditing] = useState(null)
+  const token = localStorage.getItem('access')
+
+  const authHeaders = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+
+  const fetchUsers = () => {
+    fetch('http://192.168.1.52:8000/api/users/', { headers: authHeaders })
+      .then((r) => r.json())
+      .then(setUsers)
+      .catch((e) => console.error(e))
+  }
+
+  useEffect(() => {
+    fetchUsers()
+  }, [])
+
+  const handleSave = async (data) => {
+    try {
+      const resp = await fetch(
+        editing ? `http://192.168.1.52:8000/api/users/${editing.id}/` : 'http://192.168.1.52:8000/api/users/',
+        {
+          method: editing ? 'PUT' : 'POST',
+          headers: authHeaders,
+          body: JSON.stringify(data),
+        }
+      )
+      if (!resp.ok) throw new Error('Error al guardar')
+      setModalOpen(false)
+      setEditing(null)
+      fetchUsers()
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  const handleDelete = async (u) => {
+    if (!window.confirm('¿Eliminar usuario?')) return
+    try {
+      const resp = await fetch(`http://192.168.1.52:8000/api/users/${u.id}/`, {
+        method: 'DELETE',
+        headers: authHeaders,
+      })
+      if (!resp.ok) throw new Error('Error al eliminar')
+      fetchUsers()
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-4 h-full bg-gray-50">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-800">Usuarios</h2>
+        <button
+          onClick={() => {
+            setEditing(null)
+            setModalOpen(true)
+          }}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Nuevo Usuario
+        </button>
+      </div>
+
+      <div className="space-y-2 overflow-y-auto" style={{ maxHeight: 'calc(100vh - 160px)' }}>
+        {users.map((u) => (
+          <div key={u.id} className="flex items-center justify-between p-3 bg-white rounded-lg shadow">
+            <div>
+              <p className="font-medium text-gray-800">{u.username}</p>
+              <p className="text-sm text-gray-500">{u.role === 'admin' ? 'Administrador' : 'Recepcionista'}</p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={() => {
+                  setEditing(u)
+                  setModalOpen(true)
+                }}
+                className="px-3 py-1 text-xs text-white bg-blue-600 rounded hover:bg-blue-700"
+              >
+                Editar
+              </button>
+              <button
+                onClick={() => handleDelete(u)}
+                className="px-3 py-1 text-xs text-white bg-red-600 rounded hover:bg-red-700"
+              >
+                Eliminar
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <UserFormModal
+        open={modalOpen}
+        onClose={() => {
+          setModalOpen(false)
+          setEditing(null)
+        }}
+        onSave={handleSave}
+        user={editing}
+      />
+    </div>
+  )
+}
+
+export default Usuarios


### PR DESCRIPTION
## Summary
- allow password management in user serializer
- include user role on registration
- add users page with CRUD abilities
- show logged user role in sidebar
- link to users page for admin accounts

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687d94b2b344832c9966f1f820973051