### PR TITLE
Ensure superuser role defaults to admin

### DIFF
--- a/Backend/users/models.py
+++ b/Backend/users/models.py
@@ -1,5 +1,13 @@
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, UserManager
 from django.db import models
+
+
+class CustomUserManager(UserManager):
+    """UserManager with default admin role for superusers."""
+
+    def create_superuser(self, username, email=None, password=None, **extra_fields):
+        extra_fields.setdefault('role', 'admin')
+        return super().create_superuser(username, email=email, password=password, **extra_fields)
 
 
 class User(AbstractUser):
@@ -10,6 +18,8 @@ class User(AbstractUser):
 
     role = models.CharField(max_length=20, choices=ROLE_CHOICES, default='recepcionist')
     is_active = models.BooleanField(default=True)
+
+    objects = CustomUserManager()
 
     def __str__(self):
         return self.username

--- a/Backend/users/tests.py
+++ b/Backend/users/tests.py
@@ -1,3 +1,11 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-# Create your tests here.
+
+class SuperuserRoleTest(TestCase):
+    def test_create_superuser_role_is_admin(self):
+        User = get_user_model()
+        superuser = User.objects.create_superuser(username="admin", password="pass")
+        self.assertEqual(superuser.role, "admin")
+        self.assertTrue(superuser.is_superuser)
+        self.assertTrue(superuser.is_staff)


### PR DESCRIPTION
## Summary
- set custom user manager that defaults `create_superuser` role to `admin`
- add a unit test verifying the role when creating a superuser

## Testing
- `python Backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687d9e43f960832c9b106fd33cc52ded