### PR TITLE
Fix PDF table alignment with blank rows

### DIFF
--- a/Backend/core/templates/quotes/pdf.html
+++ b/Backend/core/templates/quotes/pdf.html
@@ -1,3 +1,4 @@
+{% load pdf_extras %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -119,8 +120,8 @@
       border-collapse: collapse;
       margin: 15px 0;
       background: white;
+      table-layout: fixed;
     }
-    
     th {
       background-color: #f8f9fa;
       color: #555;
@@ -266,10 +267,18 @@
     <tbody>
       {% for detail in quote.details.all %}
       <tr>
-        <td>{{ detail.product.name }}</td>
-        <td class="text-center">{{ detail.quantity }}</td>
-        <td class="text-right">${{ detail.price_unit|floatformat:0 }}</td>
-        <td class="text-right">${{ detail.subtotal|floatformat:0 }}</td>
+        <td style="width: 45%;">{{ detail.product.name }}</td>
+        <td style="width: 15%;" class="text-center">{{ detail.quantity }}</td>
+        <td style="width: 20%;" class="text-right">${{ detail.price_unit|floatformat:0 }}</td>
+        <td style="width: 20%;" class="text-right">${{ detail.subtotal|floatformat:0 }}</td>
+      </tr>
+      {% endfor %}
+      {% for _ in blank_rows|times %}
+      <tr>
+        <td style="width: 45%;">&nbsp;</td>
+        <td style="width: 15%;" class="text-center">&nbsp;</td>
+        <td style="width: 20%;" class="text-right">&nbsp;</td>
+        <td style="width: 20%;" class="text-right">&nbsp;</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/Backend/core/templatetags/pdf_extras.py
+++ b/Backend/core/templatetags/pdf_extras.py
@@ -1,0 +1,20 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def times(number):
+    """Return a range up to the given number."""
+    return range(int(number))
+
+@register.filter
+def chunks(value, size):
+    """Break a list into chunks of given size."""
+    size = int(size)
+    value = list(value)
+    return [value[i:i + size] for i in range(0, len(value), size)]
+
+@register.simple_tag
+def blank_rows(group, size=10):
+    """Return a range for blank rows in the table."""
+    return range(size - len(group))

--- a/Backend/core/views/quotes.py
+++ b/Backend/core/views/quotes.py
@@ -21,7 +21,14 @@ class QuoteViewSet(viewsets.ModelViewSet):
         quote = self.get_object()
         template = get_template('quotes/pdf.html')
         logo_path = os.path.join(settings.BASE_DIR, 'static', 'logo.png')
-        html = template.render({'quote': quote, 'logo_path': logo_path})
+        details_count = quote.details.count()
+        blank_rows = (10 - details_count % 10) % 10
+        context = {
+            'quote': quote,
+            'logo_path': logo_path,
+            'blank_rows': blank_rows,
+        }
+        html = template.render(context)
 
         folder_path = os.path.join(settings.MEDIA_ROOT, 'quotes')
         os.makedirs(folder_path, exist_ok=True)


### PR DESCRIPTION
## Summary
- ensure product tables keep fixed layout
- preserve consistent table width across pages
- render blank rows to keep 10-row table
- expose helper template filters

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687db52468dc832cb09829500f93223d