### PR TITLE
Add product CSV import/export feature

### DIFF
--- a/Backend/core/urls.py
+++ b/Backend/core/urls.py
@@ -7,6 +7,7 @@ from core.views import (
     SalesSummaryReportView,
     CategoryViewSet,
     PaymentMethodViewSet,
+    ProductImportExportView,
 )
 from django.conf import settings
 from django.conf.urls.static import static
@@ -21,4 +22,5 @@ router.register(r'payment-methods', PaymentMethodViewSet, basename='payment-meth
 urlpatterns = [
     path('', include(router.urls)),
     path('reports/summary/', SalesSummaryReportView.as_view(), name='sales-summary-report'),
+    path('import-export/', ProductImportExportView.as_view(), name='import-export'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/Backend/core/views/__init__.py
+++ b/Backend/core/views/__init__.py
@@ -4,5 +4,6 @@ from .quotes import QuoteViewSet
 from .reports import SalesSummaryReportView
 from .categories import CategoryViewSet
 from .payment_methods import PaymentMethodViewSet
+from .import_export import ProductImportExportView
 
 

--- a/Backend/core/views/import_export.py
+++ b/Backend/core/views/import_export.py
@@ -1,0 +1,77 @@
+import csv
+from decimal import Decimal
+from django.http import HttpResponse
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from core.models import Product, Category
+from users.views import IsSuperUser
+
+
+class ProductImportExportView(APIView):
+    permission_classes = [IsAuthenticated, IsSuperUser]
+
+    def get(self, request):
+        """Export products and categories as CSV"""
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename="products.csv"'
+        writer = csv.writer(response)
+        writer.writerow([
+            'category',
+            'name',
+            'description',
+            'sku',
+            'barcode',
+            'brand',
+            'price',
+            'cost',
+            'stock',
+            'stock_minimum',
+            'unit',
+        ])
+        for p in Product.objects.select_related('category').all():
+            writer.writerow([
+                p.category.name if p.category else '',
+                p.name,
+                p.description or '',
+                p.sku or '',
+                p.barcode or '',
+                p.brand or '',
+                p.price,
+                p.cost if p.cost is not None else '',
+                p.stock,
+                p.stock_minimum,
+                p.unit or '',
+            ])
+        return response
+
+    def post(self, request):
+        """Import products and categories from uploaded CSV"""
+        file = request.FILES.get('file')
+        if not file:
+            return Response({'error': 'No file provided'}, status=400)
+        decoded = file.read().decode('utf-8').splitlines()
+        reader = csv.DictReader(decoded)
+        created = 0
+        for row in reader:
+            cat_name = row.get('category', '').strip()
+            if not cat_name:
+                continue
+            category, _ = Category.objects.get_or_create(name=cat_name)
+            product = Product(
+                name=row.get('name', '').strip(),
+                description=row.get('description', '').strip() or None,
+                sku=row.get('sku', '').strip() or None,
+                barcode=row.get('barcode', '').strip() or None,
+                brand=row.get('brand', '').strip() or None,
+                price=Decimal(row.get('price') or '0'),
+                cost=Decimal(row['cost']) if row.get('cost') else None,
+                stock=int(row.get('stock') or 0),
+                stock_minimum=int(row.get('stock_minimum') or 0),
+                unit=row.get('unit', '').strip() or None,
+                category=category,
+                created_by=request.user,
+            )
+            product.save()
+            created += 1
+        return Response({'created': created})

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import ReportesInventario from './pages/ReportesInventario.jsx'
 import ReportesFinanciero from './pages/ReportesFinanciero.jsx'
 import Cotizaciones from './pages/Cotizaciones.jsx'
 import Usuarios from './pages/Usuarios.jsx'
+import ImportExport from './pages/ImportExport.jsx'
 
 function RequireSuperuser({ children, user }) {
   if (!user?.is_superuser) {
@@ -156,6 +157,14 @@ function App() {
             element={
               <RequireSuperuser user={user}>
                 <Usuarios />
+              </RequireSuperuser>
+            }
+          />
+          <Route
+            path="/import-export"
+            element={
+              <RequireSuperuser user={user}>
+                <ImportExport />
               </RequireSuperuser>
             }
           />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -139,6 +139,15 @@ function Sidebar({ user, onLogout }) {
         </svg>
       )
     })
+    links.push({
+      to: '/import-export',
+      label: 'Importar/Exportar',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v8m4-4H8" />
+        </svg>
+      )
+    })
   }
 
   const toggleSubmenu = (index, e) => {

--- a/frontend/src/pages/ImportExport.jsx
+++ b/frontend/src/pages/ImportExport.jsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+
+function ImportExport() {
+  const token = localStorage.getItem('access')
+  const headers = { Authorization: `Bearer ${token}` }
+  const [file, setFile] = useState(null)
+  const [isUploading, setUploading] = useState(false)
+
+  const handleExport = async () => {
+    const resp = await fetch('http://192.168.1.52:8000/api/import-export/', { headers })
+    const blob = await resp.blob()
+    const url = window.URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'productos.csv'
+    a.click()
+    window.URL.revokeObjectURL(url)
+  }
+
+  const handleImport = async (e) => {
+    e.preventDefault()
+    if (!file) return
+    setUploading(true)
+    const form = new FormData()
+    form.append('file', file)
+    try {
+      const resp = await fetch('http://192.168.1.52:8000/api/import-export/', {
+        method: 'POST',
+        headers,
+        body: form,
+      })
+      if (!resp.ok) throw new Error('Error al importar')
+      alert('Importación completada')
+      setFile(null)
+    } catch (err) {
+      alert(err.message)
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  return (
+    <div className="p-6 space-y-4 bg-gray-50 h-full">
+      <h2 className="text-2xl font-bold text-gray-800">Importar / Exportar</h2>
+      <div className="space-y-3">
+        <button
+          onClick={handleExport}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Exportar CSV
+        </button>
+        <form onSubmit={handleImport} className="space-x-2 inline-block">
+          <input
+            type="file"
+            accept=".csv"
+            onChange={(e) => setFile(e.target.files[0])}
+          />
+          <button
+            type="submit"
+            disabled={isUploading || !file}
+            className="px-4 py-2 bg-green-600 text-white rounded disabled:bg-green-400"
+          >
+            {isUploading ? 'Importando...' : 'Importar'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default ImportExport


### PR DESCRIPTION
## Summary
- create `ProductImportExportView` for CSV export/import
- wire up new endpoint in backend URLs
- add ImportExport page for admins
- add sidebar link and route for superadmins

## Testing
- `python Backend/manage.py test --help` *(fails: ModuleNotFoundError)*
- `pip install -r Backend/requirements.txt` *(fails: Tunnel connection failed)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687dbbc58144832cbe3df7e2015e25c1