### PR TITLE
Fix superuser state persistence in frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,12 +23,16 @@ function RequireSuperuser({ children, user }) {
 }
 
 function App() {
-  const [user, setUser] = useState(null)
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem('user')
+    return stored ? JSON.parse(stored) : null
+  })
   const [token, setToken] = useState(localStorage.getItem('access') || '')
 
   const handleLogin = (u, t) => {
     setUser(u)
     setToken(t)
+    localStorage.setItem('user', JSON.stringify(u))
   }
 
   const handleLogout = () => {
@@ -36,6 +40,7 @@ function App() {
     setToken('')
     localStorage.removeItem('access')
     localStorage.removeItem('refresh')
+    localStorage.removeItem('user')
   }
 
   const refreshToken = async () => {

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -23,6 +23,7 @@ function Login({ onSuccess }) {
       const data = await resp.json()
       localStorage.setItem('access', data.access)
       localStorage.setItem('refresh', data.refresh)
+      localStorage.setItem('user', JSON.stringify(data.user))
       if (onSuccess) onSuccess(data.user, data.access)
     } catch (err) {
       setError(err.message)


### PR DESCRIPTION
## Summary
- persist logged-in user info across sessions
- store user info in localStorage on login
- clear stored user info on logout

## Testing
- `python3 manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687dc047a44c832cb16a7077c4b58be2