### PR TITLE
Fix receipt totals and revert logo

### DIFF
--- a/Backend/core/templates/sales/ticket.html
+++ b/Backend/core/templates/sales/ticket.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    @page { size: 80mm auto; margin: 4mm; }
+    body { font-family: Arial, sans-serif; font-size: 10px; color: #000; }
+    .logo { text-align: center; margin-bottom: 5px; }
+    .logo img { max-width: 60mm; }
+    h1 { text-align:center; font-size: 14px; margin: 4px 0; }
+    table { width:100%; border-collapse: collapse; }
+    th, td { padding: 2px 0; }
+    th { border-bottom: 1px dashed #000; font-weight: bold; }
+    tfoot td { border-top: 1px dashed #000; font-weight: bold; }
+    .text-right { text-align:right; }
+    .contact { text-align:center; margin-top:10px; font-size:9px; }
+  </style>
+</head>
+<body>
+  <div class="logo">
+    <img src="{{ logo_path }}" alt="Logo">
+  </div>
+  <h1>Boleta #{{ sale.id }}</h1>
+  <p><strong>Cliente:</strong> {{ sale.client_first_name }} {{ sale.client_last_name }} ({{ sale.client_rut }})</p>
+  <p><strong>Fecha:</strong> {{ sale.sale_date|date:"d/m/Y H:i" }}</p>
+  <table>
+    <thead>
+      <tr>
+        <th>Producto</th>
+        <th class="text-right">Cant</th>
+        <th class="text-right">Subtotal</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for detail in sale.details.all %}
+      <tr>
+        <td>{{ detail.product.name }}</td>
+        <td class="text-right">{{ detail.quantity }}</td>
+        <td class="text-right">${{ detail.subtotal|floatformat:0 }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+    <tfoot>
+      <tr>
+        <td colspan="2">Subtotal</td>
+        <td class="text-right">${{ sale.total|floatformat:0 }}</td>
+      </tr>
+      <tr>
+        <td colspan="2">IVA</td>
+        <td class="text-right">${{ sale.iva|floatformat:0 }}</td>
+      </tr>
+      <tr>
+        <td colspan="2">TOTAL</td>
+        <td class="text-right">${{ sale.total|add:sale.iva|floatformat:0 }}</td>
+      </tr>
+    </tfoot>
+  </table>
+  <div class="contact">
+    Dirección: Arturo Prat 15 Pahuil, Maule<br>
+    Teléfono: +56 9 82279511<br>
+    Email: contacto@muebleriageorge.cl
+  </div>
+</body>
+</html>

--- a/Backend/core/views/sales.py
+++ b/Backend/core/views/sales.py
@@ -1,8 +1,14 @@
-from rest_framework import viewsets, permissions
+from rest_framework import viewsets
 from core.models import Sale
 from core.serializers.sales import SaleSerializer
 from rest_framework.permissions import IsAuthenticated
 from drf_spectacular.utils import extend_schema
+from rest_framework.decorators import action
+from django.template.loader import get_template
+from xhtml2pdf import pisa
+from rest_framework.response import Response
+from django.conf import settings
+import os
 
 @extend_schema(tags=["Ventas"])
 class SaleViewSet(viewsets.ModelViewSet):
@@ -13,3 +19,26 @@ class SaleViewSet(viewsets.ModelViewSet):
     @extend_schema(summary="Registrar venta o listar historial")
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
+
+    @action(detail=True, methods=['get'], url_path='export')
+    def export_pdf(self, request, pk=None):
+        sale = self.get_object()
+        template = get_template('sales/ticket.html')
+        logo_path = os.path.join(settings.BASE_DIR, 'static', 'logo.png')
+        context = {
+            'sale': sale,
+            'logo_path': logo_path,
+        }
+        html = template.render(context)
+
+        folder_path = os.path.join(settings.MEDIA_ROOT, 'sales')
+        os.makedirs(folder_path, exist_ok=True)
+
+        file_name = f"venta_{sale.id}.pdf"
+        file_path = os.path.join(folder_path, file_name)
+
+        with open(file_path, 'wb') as pdf_file:
+            pisa.CreatePDF(html, dest=pdf_file)
+
+        file_url = request.build_absolute_uri(settings.MEDIA_URL + f'sales/{file_name}')
+        return Response({'pdf_url': file_url})

--- a/frontend/src/components/Ventas/ReceiptModal.jsx
+++ b/frontend/src/components/Ventas/ReceiptModal.jsx
@@ -1,0 +1,55 @@
+// src/components/ventas/ReceiptModal.jsx
+function ReceiptModal({ open, onClose, pdfUrl }) {
+  if (!open) return null
+
+  const handlePrint = () => {
+    const win = window.open(pdfUrl, '_blank')
+    if (win) {
+      win.addEventListener('load', () => {
+        win.print()
+      })
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-sm flex flex-col overflow-hidden">
+        <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4 flex justify-between items-center">
+          <h2 className="text-xl font-semibold">Compra finalizada</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="bg-white/10 hover:bg-white/20 text-white rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 flex items-center gap-2"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            Cerrar
+          </button>
+        </div>
+        <div className="p-6 space-y-4 text-center">
+          <p className="text-lg font-medium text-gray-700">¡Compra finalizada con éxito!</p>
+          <div className="flex justify-center gap-3">
+            <a
+              href={pdfUrl}
+              download
+              target="_blank"
+              rel="noreferrer"
+              className="bg-blue-600 hover:bg-blue-700 text-white rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-200"
+            >
+              Descargar Boleta
+            </a>
+            <button
+              onClick={handlePrint}
+              className="bg-green-600 hover:bg-green-700 text-white rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-200"
+            >
+              Imprimir
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ReceiptModal


### PR DESCRIPTION
## Summary
- update ticket totals for PDF receipts
- revert frontend logo to previous version
- clean up imports in Sale viewset

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687e7b1e15ac832c8fb0045e31afc70c