### PR TITLE
Add sales search and receipt download

### DIFF
--- a/frontend/src/pages/Inventario.jsx
+++ b/frontend/src/pages/Inventario.jsx
@@ -5,6 +5,8 @@ function Inventario() {
   const [sales, setSales] = useState([])
   const [products, setProducts] = useState([])
   const [selectedSale, setSelectedSale] = useState(null)
+  const [receiptUrl, setReceiptUrl] = useState('')
+  const [salesSearch, setSalesSearch] = useState('')
   const token = localStorage.getItem('access')
   const authHeaders = { Authorization: `Bearer ${token}` }
 
@@ -56,6 +58,33 @@ function Inventario() {
     (p) => p.stock < p.stock_minimum
   )
 
+  const filteredSales = sales.filter((s) => {
+    const fullName = `${s.client_first_name} ${s.client_last_name}`.toLowerCase()
+    const query = salesSearch.toLowerCase()
+    return (
+      s.id.toString().includes(query) ||
+      fullName.includes(query) ||
+      (s.client_rut || '').toLowerCase().includes(query)
+    )
+  })
+
+  const openSale = async (sale) => {
+    setSelectedSale(sale)
+    setReceiptUrl('')
+    try {
+      const resp = await fetch(
+        `http://192.168.1.52:8000/api/sales/${sale.id}/export/`,
+        { headers: authHeaders }
+      )
+      if (resp.ok) {
+        const data = await resp.json()
+        setReceiptUrl(data.pdf_url)
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   return (
     <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
       <div className="flex items-center justify-between">
@@ -95,13 +124,27 @@ function Inventario() {
 
         <div className="bg-white rounded-lg shadow p-4 md:row-span-2">
           <h3 className="text-lg font-semibold mb-3">Ventas registradas</h3>
-          {sales.length > 0 ? (
-            <div className="space-y-2 max-h-80 overflow-y-auto">
-              {sales.map((s) => (
+          <div className="relative mb-3">
+            <input
+              type="text"
+              placeholder="Buscar por número, nombre o RUT..."
+              className="w-full px-3 py-2 pl-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 shadow-sm text-sm"
+              value={salesSearch}
+              onChange={(e) => setSalesSearch(e.target.value)}
+            />
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+            </div>
+          </div>
+          {filteredSales.length > 0 ? (
+            <div className="space-y-2 max-h-[60vh] overflow-y-auto">
+              {filteredSales.map((s) => (
                 <div
                   key={s.id}
                   className="p-3 bg-gray-50 rounded-lg hover:bg-gray-100 cursor-pointer flex justify-between items-center"
-                  onClick={() => setSelectedSale(s)}
+                  onClick={() => openSale(s)}
                 >
                   <div>
                     <p className="font-medium text-gray-800">Venta #{s.id}</p>
@@ -143,20 +186,22 @@ function Inventario() {
       </div>
 
       {selectedSale && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg shadow-lg w-full max-w-lg p-6">
-            <div className="flex justify-between mb-4">
-              <h3 className="text-lg font-semibold">
-                Venta #{selectedSale.id}
-              </h3>
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md flex flex-col overflow-hidden">
+            <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4 flex justify-between items-center">
+              <h3 className="text-xl font-semibold">Venta #{selectedSale.id}</h3>
               <button
+                type="button"
                 onClick={() => setSelectedSale(null)}
-                className="text-gray-500 hover:text-gray-700"
+                className="bg-white/10 hover:bg-white/20 text-white rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 flex items-center gap-2"
               >
-                &#10005;
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                Cerrar
               </button>
             </div>
-            <div className="space-y-2 text-sm">
+            <div className="p-6 space-y-4 overflow-y-auto text-sm flex-1">
               <p>
                 <span className="font-medium">Cliente:</span>{' '}
                 {selectedSale.client_first_name} {selectedSale.client_last_name}
@@ -176,7 +221,7 @@ function Inventario() {
                 })}
               </p>
             </div>
-            <div className="mt-4">
+            <div>
               <h4 className="font-medium text-gray-800 mb-2">Detalles</h4>
               <ul className="space-y-1 max-h-60 overflow-y-auto text-sm">
                 {selectedSale.details.map((d, i) => (
@@ -194,6 +239,19 @@ function Inventario() {
                 ))}
               </ul>
             </div>
+            {receiptUrl && (
+              <div className="pt-4 flex justify-end">
+                <a
+                  href={receiptUrl}
+                  download
+                  target="_blank"
+                  rel="noreferrer"
+                  className="bg-blue-600 hover:bg-blue-700 text-white rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-200"
+                >
+                  Descargar Boleta
+                </a>
+              </div>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- improve `Inventario` page
  - add search field for sales
  - extend sales list height
  - match modal design with other dialogs
  - allow downloading receipt when viewing a sale

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ecb181070832c9d1b87cfb04435b1