### PR TITLE
Add new report pages and dashboard updates

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,22 @@
+export const API_BASE = 'http://192.168.1.52:8000/api'
+
+export function authHeaders() {
+  const token = localStorage.getItem('access')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+export async function fetchAll(endpoint) {
+  const items = []
+  let next = `${API_BASE}/${endpoint}`
+  while (next) {
+    const resp = await fetch(next, { headers: authHeaders() })
+    const data = await resp.json()
+    if (Array.isArray(data)) {
+      items.push(...data)
+      break
+    }
+    items.push(...(data.results || []))
+    next = data.next
+  }
+  return items
+}

--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+function DataTable({ headers, rows }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            {headers.map((h, i) => (
+              <th
+                key={i}
+                className="px-3 py-2 text-left text-xs font-semibold text-gray-700"
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-100">
+          {rows.map((row, i) => (
+            <tr key={i} className="hover:bg-gray-50">
+              {row.map((cell, j) => (
+                <td key={j} className="px-3 py-2 text-sm text-gray-700">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default DataTable

--- a/frontend/src/components/SummaryCard.jsx
+++ b/frontend/src/components/SummaryCard.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+function SummaryCard({ title, value }) {
+  return (
+    <div className="p-4 bg-white rounded-lg shadow-sm border border-gray-100">
+      <p className="text-sm text-gray-500">{title}</p>
+      <p className="text-2xl font-semibold text-gray-800">{value}</p>
+    </div>
+  )
+}
+
+export default SummaryCard

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,423 +1,120 @@
 import { useState, useEffect } from 'react'
+import SummaryCard from '@components/SummaryCard.jsx'
+import { fetchAll } from '../api.js'
+import { Link } from 'react-router-dom'
 
 function Dashboard() {
-  const today = new Date().toISOString().slice(0, 10)
-  const past = new Date(Date.now() - 29 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .slice(0, 10)
+  const [products, setProducts] = useState([])
+  const [sales, setSales] = useState([])
+  const [stats, setStats] = useState(null)
+  const [weekly, setWeekly] = useState({})
 
-  const [startDate, setStartDate] = useState(past)
-  const [endDate, setEndDate] = useState(today)
-  const [summary, setSummary] = useState(null)
-  const token = localStorage.getItem('access')
-
-  const fetchSummary = async () => {
-    const params = new URLSearchParams()
-    if (startDate) params.append('start_date', startDate)
-    if (endDate) params.append('end_date', endDate)
-    try {
-      const resp = await fetch(
-        `http://192.168.1.52:8000/api/reports/summary/?${params.toString()}`,
-        { headers: { Authorization: `Bearer ${token}` } }
-      )
-      if (!resp.ok) throw new Error('Error al cargar')
-      const data = await resp.json()
-      setSummary(data)
-    } catch {
-      setSummary(null)
-    }
+  const loadData = async () => {
+    const [prods, salesData] = await Promise.all([
+      fetchAll('products/'),
+      fetchAll('sales/')
+    ])
+    setProducts(prods)
+    setSales(salesData)
   }
 
   useEffect(() => {
-    fetchSummary()
+    loadData()
   }, [])
 
-  // Función para crear el path SVG de la curva suave
-  const createSmoothPath = (points) => {
-    if (points.length < 2) return ''
-    
-    let path = `M ${points[0].x} ${points[0].y}`
-    
-    for (let i = 1; i < points.length; i++) {
-      const prevPoint = points[i - 1]
-      const currentPoint = points[i]
-      const nextPoint = points[i + 1]
-      
-      const controlPoint1X = prevPoint.x + (currentPoint.x - prevPoint.x) * 0.3
-      const controlPoint1Y = prevPoint.y
-      const controlPoint2X = currentPoint.x - (nextPoint ? (nextPoint.x - currentPoint.x) * 0.3 : 0)
-      const controlPoint2Y = currentPoint.y
-      
-      path += ` C ${controlPoint1X} ${controlPoint1Y}, ${controlPoint2X} ${controlPoint2Y}, ${currentPoint.x} ${currentPoint.y}`
-    }
-    
-    return path
-  }
+  useEffect(() => {
+    const critical = products.filter((p) => p.stock < p.stock_minimum).length
+    const active = products.filter((p) => p.is_active).length
 
-  // Función para formatear fechas
-  const formatDate = (dateString) => {
-    if (!dateString) return ''
-    try {
-      const date = new Date(dateString + 'T00:00:00')
-      if (isNaN(date.getTime())) return ''
-      const day = date.getDate()
-      return day.toString()
-    } catch (error) {
-      console.log('Error formateando fecha:', dateString)
-      return ''
-    }
-  }
+    const limit = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    const soldProducts = new Set()
+    sales
+      .filter((s) => new Date(s.sale_date) >= limit)
+      .forEach((s) => s.details.forEach((d) => soldProducts.add(d.product_id)))
+    const withoutMove = products.filter((p) => !soldProducts.has(p.id)).length
 
-  const maxDaily = summary?.daily_sales.reduce((m, d) => Math.max(m, d.total), 0) || 0
-  const minDaily = summary?.daily_sales.reduce((m, d) => Math.min(m, d.total), maxDaily) || 0
+    const weekStart = new Date()
+    const day = weekStart.getDay()
+    const diff = (day === 0 ? 6 : day - 1)
+    weekStart.setDate(weekStart.getDate() - diff)
+    weekStart.setHours(0, 0, 0, 0)
+    const weekEnd = new Date(weekStart)
+    weekEnd.setDate(weekStart.getDate() + 6)
+
+    const salesWeek = sales.filter((s) => {
+      const d = new Date(s.sale_date)
+      return d >= weekStart && d <= weekEnd
+    })
+
+    const days = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom']
+    const daily = { Lun: 0, Mar: 0, Mié: 0, Jue: 0, Vie: 0, Sáb: 0, Dom: 0 }
+    salesWeek.forEach((s) => {
+      const d = new Date(s.sale_date)
+      const idx = (d.getDay() + 6) % 7
+      daily[days[idx]] += parseFloat(s.total)
+    })
+
+    setWeekly(daily)
+    setStats({ critical, withoutMove, salesCount: salesWeek.length, active })
+  }, [products, sales])
+
+  const maxVal = Math.max(...Object.values(weekly), 1)
+  const totalWeek = Object.values(weekly).reduce((a, b) => a + b, 0)
 
   return (
     <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
       <h2 className="text-3xl font-bold text-gray-800">Dashboard</h2>
-      
-      <div className="flex items-end gap-4">
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Desde
-          </label>
-          <input
-            type="date"
-            value={startDate}
-            onChange={(e) => setStartDate(e.target.value)}
-            className="border border-gray-300 px-3 py-2 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Hasta
-          </label>
-          <input
-            type="date"
-            value={endDate}
-            onChange={(e) => setEndDate(e.target.value)}
-            className="border border-gray-300 px-3 py-2 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          />
-        </div>
-        <button
-          onClick={fetchSummary}
-          className="h-10 px-4 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors duration-200"
-        >
-          Consultar
-        </button>
-      </div>
 
-      {summary && (
-        <div className="space-y-6">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <div className="p-4 bg-white rounded-lg shadow-sm border border-gray-100">
-              <p className="text-sm text-gray-500">Total Ventas</p>
-              <p className="text-2xl font-semibold text-gray-800">
-                {summary.total_ventas.toLocaleString('es-CL', {
-                  minimumFractionDigits: 0,
-                  maximumFractionDigits: 0,
-                })}
-              </p>
-            </div>
-            <div className="p-4 bg-white rounded-lg shadow-sm border border-gray-100">
-              <p className="text-sm text-gray-500">IVA</p>
-              <p className="text-2xl font-semibold text-gray-800">
-                {summary.total_iva.toLocaleString('es-CL', {
-                  minimumFractionDigits: 0,
-                  maximumFractionDigits: 0,
-                })}
-              </p>
-            </div>
-            <div className="p-4 bg-white rounded-lg shadow-sm border border-gray-100">
-              <p className="text-sm text-gray-500">Costos</p>
-              <p className="text-2xl font-semibold text-gray-800">
-                {summary.total_costos.toLocaleString('es-CL', {
-                  minimumFractionDigits: 0,
-                  maximumFractionDigits: 0,
-                })}
-              </p>
-            </div>
-            <div className="p-4 bg-white rounded-lg shadow-sm border border-gray-100">
-              <p className="text-sm text-gray-500">Ganancia</p>
-              <p className="text-2xl font-semibold text-gray-800">
-                {summary.ganancia_neta.toLocaleString('es-CL', {
-                  minimumFractionDigits: 0,
-                  maximumFractionDigits: 0,
-                })}
-              </p>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {/* Gráfico de ventas diarias mejorado */}
-            <div className="p-6 bg-white rounded-lg shadow-lg border border-gray-100">
-              <div className="flex justify-between items-center mb-6">
-                <h3 className="text-lg font-semibold text-gray-800">Ventas diarias</h3>
-                <div className="text-sm text-gray-500">
-                  {summary.daily_sales.length > 0 && (
-                    <span>Promedio: {Math.round(summary.daily_sales.reduce((sum, d) => sum + d.total, 0) / summary.daily_sales.length).toLocaleString('es-CL')}</span>
-                  )}
-                </div>
-              </div>
-              
-              {summary.daily_sales.length > 0 ? (
-                <div className="relative">
-                  {(() => {
-                    // Configuración del gráfico
-                    const chartWidth = 480
-                    const chartHeight = 280
-                    const paddingLeft = 60
-                    const paddingRight = 20
-                    const paddingTop = 20
-                    const paddingBottom = 60
-                    
-                    const plotWidth = chartWidth - paddingLeft - paddingRight
-                    const plotHeight = chartHeight - paddingTop - paddingBottom
-                    
-                    // Crear puntos para el gráfico
-                    const points = summary.daily_sales.map((d, i) => ({
-                      x: paddingLeft + (i / Math.max(summary.daily_sales.length - 1, 1)) * plotWidth,
-                      y: paddingTop + (1 - (d.total - minDaily) / Math.max(maxDaily - minDaily, 1)) * plotHeight,
-                      value: d.total,
-                      date: d.date
-                    }))
-
-                    const smoothPath = createSmoothPath(points)
-                    const areaPath = smoothPath + ` L ${paddingLeft + plotWidth} ${paddingTop + plotHeight} L ${paddingLeft} ${paddingTop + plotHeight} Z`
-
-                    // Calcular ticks del eje Y
-                    const yTicks = 5
-                    const yStep = (maxDaily - minDaily) / (yTicks - 1)
-                    const yTickValues = Array.from({length: yTicks}, (_, i) => minDaily + i * yStep)
-
-                    return (
-                      <div className="w-full">
-                        <svg 
-                          width={chartWidth} 
-                          height={chartHeight} 
-                          viewBox={`0 0 ${chartWidth} ${chartHeight}`}
-                          className="w-full h-auto max-h-80"
-                          style={{ minHeight: '280px' }}
-                        >
-                          {/* Grid horizontal */}
-                          {yTickValues.map((value, i) => {
-                            const y = paddingTop + (1 - (value - minDaily) / Math.max(maxDaily - minDaily, 1)) * plotHeight
-                            return (
-                              <g key={i}>
-                                <line
-                                  x1={paddingLeft}
-                                  y1={y}
-                                  x2={paddingLeft + plotWidth}
-                                  y2={y}
-                                  stroke="#f3f4f6"
-                                  strokeWidth="1"
-                                />
-                                <text
-                                  x={paddingLeft - 10}
-                                  y={y + 4}
-                                  textAnchor="end"
-                                  className="text-xs fill-gray-500"
-                                >
-                                  {value.toLocaleString('es-CL', { 
-                                    minimumFractionDigits: 0, 
-                                    maximumFractionDigits: 0,
-                                    notation: 'compact'
-                                  })}
-                                </text>
-                              </g>
-                            )
-                          })}
-
-                          {/* Grid vertical */}
-                          {points.map((point, i) => {
-                            if (i % Math.max(1, Math.floor(points.length / 6)) === 0) {
-                              return (
-                                <line
-                                  key={i}
-                                  x1={point.x}
-                                  y1={paddingTop}
-                                  x2={point.x}
-                                  y2={paddingTop + plotHeight}
-                                  stroke="#f9fafb"
-                                  strokeWidth="1"
-                                />
-                              )
-                            }
-                            return null
-                          })}
-
-                          {/* Área bajo la curva con gradiente */}
-                          <defs>
-                            <linearGradient id="salesGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                              <stop offset="0%" stopColor="#3b82f6" stopOpacity="0.3"/>
-                              <stop offset="100%" stopColor="#3b82f6" stopOpacity="0.05"/>
-                            </linearGradient>
-                            <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-                              <feDropShadow dx="0" dy="2" stdDeviation="4" floodColor="rgba(59, 130, 246, 0.2)"/>
-                            </filter>
-                          </defs>
-
-                          <path
-                            d={areaPath}
-                            fill="url(#salesGradient)"
-                          />
-                          
-                          {/* Línea principal con sombra */}
-                          <path
-                            d={smoothPath}
-                            stroke="#3b82f6"
-                            strokeWidth="3"
-                            fill="none"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            filter="url(#shadow)"
-                          />
-                          
-                          {/* Puntos interactivos */}
-                          {points.map((point, i) => (
-                            <g key={i}>
-                              <circle
-                                cx={point.x}
-                                cy={point.y}
-                                r="6"
-                                fill="white"
-                                stroke="#3b82f6"
-                                strokeWidth="3"
-                                className="hover:r-8 transition-all duration-200 cursor-pointer"
-                              />
-                              <circle
-                                cx={point.x}
-                                cy={point.y}
-                                r="3"
-                                fill="#3b82f6"
-                              />
-                              {/* Tooltip invisible para hover */}
-                              <circle
-                                cx={point.x}
-                                cy={point.y}
-                                r="12"
-                                fill="transparent"
-                                className="hover:fill-blue-50 cursor-pointer"
-                              >
-                                <title>{`${formatDate(point.date)}: ${point.value.toLocaleString('es-CL')}`}</title>
-                              </circle>
-                            </g>
-                          ))}
-
-                          {/* Etiquetas del eje X */}
-                          {points.map((point, i) => {
-                            if (i % Math.max(1, Math.floor(points.length / 6)) === 0 || i === points.length - 1) {
-                              return (
-                                <text
-                                  key={i}
-                                  x={point.x}
-                                  y={paddingTop + plotHeight + 20}
-                                  textAnchor="middle"
-                                  className="text-xs fill-gray-600"
-                                >
-                                  {formatDate(point.date)}
-                                </text>
-                              )
-                            }
-                            return null
-                          })}
-
-                          {/* Líneas de los ejes */}
-                          <line
-                            x1={paddingLeft}
-                            y1={paddingTop + plotHeight}
-                            x2={paddingLeft + plotWidth}
-                            y2={paddingTop + plotHeight}
-                            stroke="#e5e7eb"
-                            strokeWidth="2"
-                          />
-                          <line
-                            x1={paddingLeft}
-                            y1={paddingTop}
-                            x2={paddingLeft}
-                            y2={paddingTop + plotHeight}
-                            stroke="#e5e7eb"
-                            strokeWidth="2"
-                          />
-                        </svg>
-
-                        {/* Leyenda */}
-                        <div className="flex items-center justify-center mt-4 space-x-6 text-sm text-gray-600">
-                          <div className="flex items-center">
-                            <div className="w-3 h-3 bg-blue-500 rounded-full mr-2"></div>
-                            <span>Ventas diarias</span>
-                          </div>
-                          <div className="flex items-center">
-                            <div className="w-3 h-1 bg-gradient-to-r from-blue-500 to-blue-200 rounded mr-2"></div>
-                            <span>Tendencia</span>
-                          </div>
-                        </div>
-                      </div>
-                    )
-                  })()}
-                </div>
-              ) : (
-                <div className="flex items-center justify-center h-64 text-gray-500 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
-                  <div className="text-center">
-                    <div className="text-4xl text-gray-300 mb-2">📊</div>
-                    <p className="text-sm font-medium">No hay ventas registradas</p>
-                    <p className="text-xs text-gray-400 mt-1">en este período</p>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Columna de información de productos */}
-            <div className="space-y-4">
-              {/* Producto más vendido */}
-              <div className="p-4 bg-white rounded-lg shadow">
-                <p className="text-sm text-gray-500 mb-2">Producto más vendido</p>
-                {summary.best_selling_product ? (
-                  <>
-                    <p className="font-medium text-gray-800">
-                      {summary.best_selling_product.name}
-                    </p>
-                    <p className="text-sm text-gray-600">
-                      Cantidad: {summary.best_selling_product.quantity}
-                    </p>
-                  </>
-                ) : (
-                  <p className="text-sm text-gray-500 italic">
-                    No hay productos vendidos en este período
-                  </p>
-                )}
-              </div>
-
-              {/* Productos con stock bajo */}
-              <div className="p-4 bg-white rounded-lg shadow">
-                <p className="text-sm font-medium text-gray-800 mb-3">
-                  Productos con stock bajo
-                </p>
-                {summary.low_stock_products.length > 0 ? (
-                  <ul className="space-y-2">
-                    {summary.low_stock_products.map((p) => (
-                      <li key={p.id} className="flex justify-between items-start">
-                        <div>
-                          <p className="text-sm text-gray-700">{p.name}</p>
-                          {p.barcode && (
-                            <p className="text-xs text-gray-500">Cod: {p.barcode}</p>
-                          )}
-                        </div>
-                        <span className="text-sm text-orange-600 font-medium">
-                          {p.stock}/{p.stock_minimum}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="text-sm text-gray-500 italic">
-                    No hay productos con stock bajo
-                  </p>
-                )}
-              </div>
-            </div>
-          </div>
+      {stats && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <SummaryCard title="Stock crítico" value={stats.critical} />
+          <SummaryCard title="Sin movimiento" value={stats.withoutMove} />
+          <SummaryCard title="Ventas semana" value={stats.salesCount} />
+          <SummaryCard title="Productos activos" value={stats.active} />
         </div>
       )}
+
+      <div className="bg-white p-4 rounded-lg shadow">
+        <h3 className="font-semibold mb-2">Ventas por día de la semana</h3>
+        <div className="flex items-end h-48 gap-3">
+          {Object.entries(weekly).map(([d, val]) => (
+            <div key={d} className="flex-1 flex flex-col items-center">
+              <div className="w-4 bg-blue-500" style={{ height: `${(val / maxVal) * 100}%` }}></div>
+              <span className="text-xs mt-1">{d}</span>
+            </div>
+          ))}
+        </div>
+        <p className="text-sm text-center mt-2 font-medium">
+          Total semana: {totalWeek.toLocaleString('es-CL', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <Link
+          to="/inventario/productos"
+          className="bg-blue-600 text-white rounded-lg p-4 flex items-center justify-center hover:bg-blue-700"
+        >
+          Agregar nuevo producto
+        </Link>
+        <Link
+          to="/ventas"
+          className="bg-blue-600 text-white rounded-lg p-4 flex items-center justify-center hover:bg-blue-700"
+        >
+          Registrar venta
+        </Link>
+        <Link
+          to="/inventario"
+          className="bg-blue-600 text-white rounded-lg p-4 flex items-center justify-center hover:bg-blue-700"
+        >
+          Ver inventario
+        </Link>
+        <Link
+          to="/reportes"
+          className="bg-blue-600 text-white rounded-lg p-4 flex items-center justify-center hover:bg-blue-700"
+        >
+          Ir a reportes
+        </Link>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/Reportes.jsx
+++ b/frontend/src/pages/Reportes.jsx
@@ -1,10 +1,175 @@
-import React from 'react'
+import { useState, useEffect } from 'react'
+import SummaryCard from '@components/SummaryCard.jsx'
+import DataTable from '@components/DataTable.jsx'
+import { fetchAll } from '../api.js'
 
 function Reportes() {
+  const today = new Date().toISOString().slice(0, 10)
+  const first = today.slice(0, 8) + '01'
+  const [startDate, setStartDate] = useState(first)
+  const [endDate, setEndDate] = useState(today)
+  const [summary, setSummary] = useState(null)
+  const [monthly, setMonthly] = useState([])
+  const [topProducts, setTopProducts] = useState([])
+  const [lowDays, setLowDays] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchData = async () => {
+    setLoading(true)
+    const [sales, products] = await Promise.all([
+      fetchAll('sales/'),
+      fetchAll('products/')
+    ])
+    const start = new Date(startDate)
+    const end = new Date(endDate + 'T23:59:59')
+    const filtered = sales.filter((s) => {
+      const d = new Date(s.sale_date)
+      return d >= start && d <= end
+    })
+    let total = 0
+    const daily = {}
+    const monthlyMap = {}
+    const countMap = {}
+    filtered.forEach((s) => {
+      total += parseFloat(s.total)
+      const day = s.sale_date.slice(0, 10)
+      daily[day] = (daily[day] || 0) + parseFloat(s.total)
+      const month = s.sale_date.slice(0, 7)
+      if (!monthlyMap[month]) monthlyMap[month] = { ventas: 0, costos: 0 }
+      let saleCost = 0
+      s.details.forEach((d) => {
+        countMap[d.product_id] = (countMap[d.product_id] || 0) + d.quantity
+        const p = products.find((pr) => pr.id === d.product_id)
+        if (p && p.cost) saleCost += parseFloat(p.cost) * d.quantity
+      })
+      monthlyMap[month].ventas += parseFloat(s.total)
+      monthlyMap[month].costos += saleCost
+    })
+    const monthlyArr = Object.entries(monthlyMap)
+      .sort()
+      .map(([m, val]) => ({ month: m, ventas: val.ventas, utilidad: val.ventas - val.costos }))
+    const costosTotales = monthlyArr.reduce((sum, m) => sum + (m.ventas - m.utilidad), 0)
+    const avgDaily = Object.values(daily).reduce((a, b) => a + b, 0) / (Object.keys(daily).length || 1)
+    const low = Object.entries(daily)
+      .filter(([, t]) => t < avgDaily * 0.5)
+      .map(([d]) => d)
+    const tops = Object.entries(countMap)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([id, qty]) => ({
+        id: parseInt(id),
+        qty,
+        name: products.find((p) => p.id === parseInt(id))?.name || `Producto ${id}`
+      }))
+    const lowStock = products.filter((p) => p.stock < p.stock_minimum)
+    setSummary({ totalVentas: total, utilidad: total - costosTotales, lowStock })
+    setMonthly(monthlyArr)
+    setTopProducts(tops)
+    setLowDays(low)
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  const maxVal = Math.max(...monthly.map((m) => Math.max(m.ventas, m.utilidad)), 1)
+
   return (
-    <div className="p-4">
-      <h2 className="text-2xl font-bold mb-4">Reportes</h2>
-      <p>Generación de informes y estadísticas.</p>
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <h2 className="text-3xl font-bold text-gray-800">Reportes</h2>
+
+      <div className="flex items-end gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Desde</label>
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="border border-gray-300 px-3 py-2 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Hasta</label>
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="border border-gray-300 px-3 py-2 rounded-md"
+          />
+        </div>
+        <button
+          onClick={fetchData}
+          className="h-10 px-4 bg-blue-600 hover:bg-blue-700 text-white rounded-md"
+        >
+          Consultar
+        </button>
+      </div>
+
+      {summary && (
+        <div className="space-y-6">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <SummaryCard
+              title="Total Ventas"
+              value={summary.totalVentas.toLocaleString('es-CL', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0
+              })}
+            />
+            <SummaryCard
+              title="Utilidad Neta"
+              value={summary.utilidad.toLocaleString('es-CL', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0
+              })}
+            />
+            <SummaryCard title="Productos con stock crítico" value={summary.lowStock.length} />
+            <SummaryCard title="Días con ventas bajas" value={lowDays.length} />
+          </div>
+
+          <div className="bg-white p-6 rounded-lg shadow space-y-4">
+            <h3 className="font-semibold text-gray-800">Comparativa mensual</h3>
+            <div className="flex items-end h-48 gap-3">
+              {monthly.map((m) => (
+                <div key={m.month} className="flex-1 flex flex-col items-center">
+                  <div className="w-4 bg-blue-500" style={{ height: `${(m.ventas / maxVal) * 100}%` }}></div>
+                  <div className="w-4 bg-green-500 mt-1" style={{ height: `${(m.utilidad / maxVal) * 100}%` }}></div>
+                  <span className="text-xs mt-1">{m.month.slice(5)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-6">
+            <div className="bg-white p-4 rounded-lg shadow">
+              <h3 className="font-semibold mb-2">Top 5 productos</h3>
+              <DataTable
+                headers={["Producto", "Cantidad"]}
+                rows={topProducts.map((p) => [p.name, p.qty])}
+              />
+            </div>
+            <div className="bg-white p-4 rounded-lg shadow">
+              <h3 className="font-semibold mb-2">Productos con stock crítico</h3>
+              {summary.lowStock.length > 0 ? (
+                <ul className="space-y-1 text-sm">
+                  {summary.lowStock.map((p) => (
+                    <li key={p.id} className="flex justify-between">
+                      <span>{p.name}</span>
+                      <span className="text-orange-600 font-medium">
+                        {p.stock}/{p.stock_minimum}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-gray-500">Sin alertas</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {loading && <p className="text-sm">Cargando...</p>}
     </div>
   )
 }

--- a/frontend/src/pages/ReportesFinanciero.jsx
+++ b/frontend/src/pages/ReportesFinanciero.jsx
@@ -1,8 +1,148 @@
+import { useState, useEffect } from 'react'
+import SummaryCard from '@components/SummaryCard.jsx'
+import DataTable from '@components/DataTable.jsx'
+import { fetchAll } from '../api.js'
+
 function ReportesFinanciero() {
+  const today = new Date().toISOString().slice(0, 10)
+  const first = today.slice(0, 8) + '01'
+  const [startDate, setStartDate] = useState(first)
+  const [endDate, setEndDate] = useState(today)
+  const [summary, setSummary] = useState(null)
+  const [byCat, setByCat] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  const loadData = async () => {
+    setLoading(true)
+    const [sales, products, categories] = await Promise.all([
+      fetchAll('sales/'),
+      fetchAll('products/'),
+      fetchAll('categories/')
+    ])
+    const start = new Date(startDate)
+    const end = new Date(endDate + 'T23:59:59')
+    const filtered = sales.filter((s) => {
+      const d = new Date(s.sale_date)
+      return d >= start && d <= end
+    })
+    let ingresos = 0
+    let costos = 0
+    const catMap = {}
+    filtered.forEach((s) => {
+      let saleCost = 0
+      s.details.forEach((d) => {
+        const p = products.find((pr) => pr.id === d.product_id)
+        if (!p) return
+        ingresos += d.subtotal
+        saleCost += (p.cost || 0) * d.quantity
+        const cat = p.category
+        if (!catMap[cat]) catMap[cat] = { ingresos: 0, costos: 0 }
+        catMap[cat].ingresos += d.subtotal
+        catMap[cat].costos += (p.cost || 0) * d.quantity
+      })
+      costos += saleCost
+    })
+    const utilidad = ingresos - costos
+    const catArray = Object.entries(catMap).map(([id, val]) => ({
+      categoria: categories.find((c) => c.id === parseInt(id))?.name || id,
+      ingresos: val.ingresos,
+      utilidad: val.ingresos - val.costos
+    }))
+    setSummary({ ingresos, costos, utilidad })
+    setByCat(catArray)
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  const maxVal = Math.max(...byCat.map((c) => c.ingresos), 1)
+
   return (
-    <div className="p-6">
-      <h2 className="text-2xl font-bold mb-4">Reporte Financiero</h2>
-      <p className="text-gray-700">Sección para reportes financieros.</p>
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <h2 className="text-3xl font-bold text-gray-800 mb-4">Reporte Financiero</h2>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <div>
+          <label className="text-sm text-gray-700">Desde</label>
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="border border-gray-300 px-3 py-2 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="text-sm text-gray-700">Hasta</label>
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="border border-gray-300 px-3 py-2 rounded-md"
+          />
+        </div>
+        <button onClick={loadData} className="h-10 px-4 bg-blue-600 text-white rounded-md">
+          Consultar
+        </button>
+        <button onClick={() => window.print()} className="h-10 px-4 bg-green-600 text-white rounded-md">
+          Exportar PDF
+        </button>
+      </div>
+
+      {summary && (
+        <div className="space-y-6">
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <SummaryCard
+              title="Ingresos"
+              value={summary.ingresos.toLocaleString('es-CL', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0
+              })}
+            />
+            <SummaryCard
+              title="Egresos"
+              value={summary.costos.toLocaleString('es-CL', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0
+              })}
+            />
+            <SummaryCard
+              title="Utilidad Neta"
+              value={summary.utilidad.toLocaleString('es-CL', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0
+              })}
+            />
+          </div>
+
+          <div className="bg-white p-4 rounded-lg shadow">
+            <h3 className="font-semibold mb-2">Ingresos por categoría</h3>
+            <div className="flex items-end h-48 gap-3">
+              {byCat.map((c) => (
+                <div key={c.categoria} className="flex-1 flex flex-col items-center">
+                  <div className="w-4 bg-blue-500" style={{ height: `${(c.ingresos / maxVal) * 100}%` }}></div>
+                  <span className="text-xs mt-1">{c.categoria}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="bg-white p-4 rounded-lg shadow">
+            <h3 className="font-semibold mb-2">Detalle por categoría</h3>
+            <DataTable
+              headers={["Categoría", "Ingresos", "Utilidad"]}
+              rows={byCat.map((c) => [
+                c.categoria,
+                c.ingresos.toLocaleString('es-CL', { minimumFractionDigits: 0, maximumFractionDigits: 0 }),
+                c.utilidad.toLocaleString('es-CL', { minimumFractionDigits: 0, maximumFractionDigits: 0 })
+              ])}
+            />
+          </div>
+        </div>
+      )}
+
+      {loading && <p className="text-sm">Cargando...</p>}
     </div>
   )
 }

--- a/frontend/src/pages/ReportesInventario.jsx
+++ b/frontend/src/pages/ReportesInventario.jsx
@@ -1,8 +1,140 @@
+import { useState, useEffect } from 'react'
+import DataTable from '@components/DataTable.jsx'
+import { fetchAll } from '../api.js'
+
 function ReportesInventario() {
+  const [products, setProducts] = useState([])
+  const [sales, setSales] = useState([])
+  const [categories, setCategories] = useState([])
+  const [catFilter, setCatFilter] = useState('')
+  const [brandFilter, setBrandFilter] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [lowMovement, setLowMovement] = useState([])
+
+  const loadData = async () => {
+    setLoading(true)
+    const [prods, salesData, cats] = await Promise.all([
+      fetchAll('products/'),
+      fetchAll('sales/'),
+      fetchAll('categories/')
+    ])
+    setProducts(prods)
+    setSales(salesData)
+    setCategories(cats)
+    const limit = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000)
+    const movement = {}
+    salesData
+      .filter((s) => new Date(s.sale_date) >= limit)
+      .forEach((s) => {
+        s.details.forEach((d) => {
+          movement[d.product_id] = (movement[d.product_id] || 0) + d.quantity
+        })
+      })
+    const low = prods
+      .map((p) => ({ ...p, qty: movement[p.id] || 0 }))
+      .sort((a, b) => a.qty - b.qty)
+      .slice(0, 5)
+    setLowMovement(low)
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  const saleMap = {}
+  sales.forEach((s) => {
+    s.details.forEach((d) => {
+      const date = new Date(s.sale_date)
+      if (!saleMap[d.product_id] || date > saleMap[d.product_id]) {
+        saleMap[d.product_id] = date
+      }
+    })
+  })
+
+  const filtered = products.filter(
+    (p) =>
+      (catFilter === '' || p.category === parseInt(catFilter)) &&
+      (brandFilter === '' || (p.brand || '').toLowerCase().includes(brandFilter.toLowerCase()))
+  )
+
   return (
-    <div className="p-6">
-      <h2 className="text-2xl font-bold mb-4">Reporte de Inventario</h2>
-      <p className="text-gray-700">Sección para reportes detallados de inventario.</p>
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <h2 className="text-3xl font-bold text-gray-800 mb-4">Reporte de Inventario</h2>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <div>
+          <label className="text-sm text-gray-700">Categoría</label>
+          <select
+            value={catFilter}
+            onChange={(e) => setCatFilter(e.target.value)}
+            className="border border-gray-300 px-3 py-2 rounded-md"
+          >
+            <option value="">Todas</option>
+            {categories.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="text-sm text-gray-700">Proveedor</label>
+          <input
+            type="text"
+            value={brandFilter}
+            onChange={(e) => setBrandFilter(e.target.value)}
+            className="border border-gray-300 px-3 py-2 rounded-md"
+          />
+        </div>
+        <button
+          onClick={() => window.print()}
+          className="h-10 px-4 bg-blue-600 text-white rounded-md"
+        >
+          Exportar PDF
+        </button>
+        <button
+          onClick={() => window.print()}
+          className="h-10 px-4 bg-green-600 text-white rounded-md"
+        >
+          Exportar Excel
+        </button>
+      </div>
+
+      <DataTable
+        headers={[
+          'Nombre',
+          'Categoría',
+          'Stock',
+          'Stock mínimo',
+          'Última venta'
+        ]}
+        rows={filtered.map((p) => [
+          p.name,
+          categories.find((c) => c.id === p.category)?.name || '-',
+          p.stock,
+          p.stock_minimum,
+          saleMap[p.id] ? saleMap[p.id].toLocaleDateString() : '-'
+        ])}
+      />
+
+      <div className="bg-white rounded-lg shadow p-4">
+        <h3 className="font-semibold mb-2">Productos con menor movimiento</h3>
+        {lowMovement.length > 0 ? (
+          <ul className="space-y-1 text-sm">
+            {lowMovement.map((p) => (
+              <li key={p.id} className="flex justify-between">
+                <span>{p.name}</span>
+                <span>{p.qty}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-gray-500">Sin datos</p>
+        )}
+      </div>
+
+      {loading && <p className="text-sm">Cargando...</p>}
     </div>
   )
 }

--- a/frontend/src/pages/ReportesVentas.jsx
+++ b/frontend/src/pages/ReportesVentas.jsx
@@ -1,8 +1,163 @@
+import { useState, useEffect } from 'react'
+import DataTable from '@components/DataTable.jsx'
+import { fetchAll } from '../api.js'
+
 function ReportesVentas() {
+  const today = new Date().toISOString().slice(0, 10)
+  const first = today.slice(0, 8) + '01'
+  const [startDate, setStartDate] = useState(first)
+  const [endDate, setEndDate] = useState(today)
+  const [sales, setSales] = useState([])
+  const [products, setProducts] = useState([])
+  const [users, setUsers] = useState([])
+  const [userFilter, setUserFilter] = useState('')
+  const [prodFilter, setProdFilter] = useState('')
+  const [topProducts, setTopProducts] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  const loadData = async () => {
+    setLoading(true)
+    const [salesData, productsData, usersData] = await Promise.all([
+      fetchAll('sales/'),
+      fetchAll('products/'),
+      fetchAll('users/')
+    ])
+    setSales(salesData)
+    setProducts(productsData)
+    setUsers(usersData)
+    setLoading(false)
+    const counts = {}
+    salesData.forEach((s) => {
+      s.details.forEach((d) => {
+        counts[d.product_id] = (counts[d.product_id] || 0) + d.quantity
+      })
+    })
+    const tops = Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([id, qty]) => ({
+        name: productsData.find((p) => p.id === parseInt(id))?.name || id,
+        qty
+      }))
+    setTopProducts(tops)
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  const start = new Date(startDate)
+  const end = new Date(endDate + 'T23:59:59')
+  const filtered = sales.filter((s) => {
+    const d = new Date(s.sale_date)
+    return (
+      d >= start &&
+      d <= end &&
+      (userFilter === '' || s.agent === parseInt(userFilter)) &&
+      (prodFilter === '' || s.details.some((dt) => dt.product_id === parseInt(prodFilter)))
+    )
+  })
+
+  const daily = {}
+  filtered.forEach((s) => {
+    const day = s.sale_date.slice(0, 10)
+    daily[day] = (daily[day] || 0) + parseFloat(s.total)
+  })
+  const maxVal = Math.max(...Object.values(daily), 1)
+
   return (
-    <div className="p-6">
-      <h2 className="text-2xl font-bold mb-4">Reporte de Ventas</h2>
-      <p className="text-gray-700">Sección para reportes detallados de ventas.</p>
+    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+      <h2 className="text-3xl font-bold text-gray-800 mb-4">Reporte de Ventas</h2>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <div>
+          <label className="text-sm text-gray-700">Desde</label>
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="border border-gray-300 px-3 py-2 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="text-sm text-gray-700">Hasta</label>
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="border border-gray-300 px-3 py-2 rounded-md"
+          />
+        </div>
+        <div>
+          <label className="text-sm text-gray-700">Vendedor</label>
+          <select
+            value={userFilter}
+            onChange={(e) => setUserFilter(e.target.value)}
+            className="border border-gray-300 px-3 py-2 rounded-md"
+          >
+            <option value="">Todos</option>
+            {users.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.username}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="text-sm text-gray-700">Producto</label>
+          <select
+            value={prodFilter}
+            onChange={(e) => setProdFilter(e.target.value)}
+            className="border border-gray-300 px-3 py-2 rounded-md"
+          >
+            <option value="">Todos</option>
+            {products.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button onClick={() => window.print()} className="h-10 px-4 bg-blue-600 text-white rounded-md">
+          Exportar PDF
+        </button>
+        <button onClick={() => window.print()} className="h-10 px-4 bg-green-600 text-white rounded-md">
+          Exportar Excel
+        </button>
+      </div>
+
+      <DataTable
+        headers={["Fecha", "ID", "Cliente", "Total", "Vendedor"]}
+        rows={filtered.map((s) => [
+          new Date(s.sale_date).toLocaleDateString(),
+          s.id,
+          `${s.client_first_name} ${s.client_last_name}`,
+          parseFloat(s.total).toLocaleString('es-CL', {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0
+          }),
+          users.find((u) => u.id === s.agent)?.username || s.agent
+        ])}
+      />
+
+      <div className="bg-white p-4 rounded-lg shadow">
+        <h3 className="font-semibold mb-2">Ventas por día</h3>
+        <div className="flex items-end h-48 gap-3">
+          {Object.entries(daily).map(([day, val]) => (
+            <div key={day} className="flex-1 flex flex-col items-center">
+              <div className="w-4 bg-blue-500" style={{ height: `${(val / maxVal) * 100}%` }}></div>
+              <span className="text-xs mt-1">{day.split('-')[2]}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow">
+        <h3 className="font-semibold mb-2">Top 10 productos</h3>
+        <DataTable headers={["Producto", "Cantidad"]} rows={topProducts.map((t) => [t.name, t.qty])} />
+      </div>
+
+      {loading && <p className="text-sm">Cargando...</p>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add SummaryCard and DataTable reusable components
- implement new reporting dashboard
- implement inventory, sales and financial reports
- create API helper
- update operations dashboard with weekly stats

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687fc64723f4832ca6d711b2f8cdb77a