### PR TITLE
Add scrollable sections to reports

### DIFF
--- a/frontend/src/pages/Reportes.jsx
+++ b/frontend/src/pages/Reportes.jsx
@@ -143,15 +143,17 @@ function Reportes() {
           <div className="grid md:grid-cols-2 gap-6">
             <div className="bg-white p-4 rounded-lg shadow">
               <h3 className="font-semibold mb-2">Top 5 productos</h3>
-              <DataTable
-                headers={["Producto", "Cantidad"]}
-                rows={topProducts.map((p) => [p.name, p.qty])}
-              />
+              <div className="max-h-[60vh] overflow-y-auto">
+                <DataTable
+                  headers={["Producto", "Cantidad"]}
+                  rows={topProducts.map((p) => [p.name, p.qty])}
+                />
+              </div>
             </div>
             <div className="bg-white p-4 rounded-lg shadow">
               <h3 className="font-semibold mb-2">Productos con stock crítico</h3>
               {summary.lowStock.length > 0 ? (
-                <ul className="space-y-1 text-sm">
+                <ul className="space-y-1 text-sm max-h-60 overflow-y-auto">
                   {summary.lowStock.map((p) => (
                     <li key={p.id} className="flex justify-between">
                       <span>{p.name}</span>

--- a/frontend/src/pages/ReportesFinanciero.jsx
+++ b/frontend/src/pages/ReportesFinanciero.jsx
@@ -130,14 +130,16 @@ function ReportesFinanciero() {
 
           <div className="bg-white p-4 rounded-lg shadow">
             <h3 className="font-semibold mb-2">Detalle por categoría</h3>
-            <DataTable
-              headers={["Categoría", "Ingresos", "Utilidad"]}
-              rows={byCat.map((c) => [
-                c.categoria,
-                c.ingresos.toLocaleString('es-CL', { minimumFractionDigits: 0, maximumFractionDigits: 0 }),
-                c.utilidad.toLocaleString('es-CL', { minimumFractionDigits: 0, maximumFractionDigits: 0 })
-              ])}
-            />
+            <div className="max-h-[60vh] overflow-y-auto">
+              <DataTable
+                headers={["Categoría", "Ingresos", "Utilidad"]}
+                rows={byCat.map((c) => [
+                  c.categoria,
+                  c.ingresos.toLocaleString('es-CL', { minimumFractionDigits: 0, maximumFractionDigits: 0 }),
+                  c.utilidad.toLocaleString('es-CL', { minimumFractionDigits: 0, maximumFractionDigits: 0 })
+                ])}
+              />
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/pages/ReportesInventario.jsx
+++ b/frontend/src/pages/ReportesInventario.jsx
@@ -101,27 +101,29 @@ function ReportesInventario() {
         </button>
       </div>
 
-      <DataTable
-        headers={[
-          'Nombre',
-          'Categoría',
-          'Stock',
-          'Stock mínimo',
-          'Última venta'
-        ]}
-        rows={filtered.map((p) => [
-          p.name,
-          categories.find((c) => c.id === p.category)?.name || '-',
-          p.stock,
-          p.stock_minimum,
-          saleMap[p.id] ? saleMap[p.id].toLocaleDateString() : '-'
-        ])}
-      />
+      <div className="max-h-[60vh] overflow-y-auto">
+        <DataTable
+          headers={[
+            'Nombre',
+            'Categoría',
+            'Stock',
+            'Stock mínimo',
+            'Última venta'
+          ]}
+          rows={filtered.map((p) => [
+            p.name,
+            categories.find((c) => c.id === p.category)?.name || '-',
+            p.stock,
+            p.stock_minimum,
+            saleMap[p.id] ? saleMap[p.id].toLocaleDateString() : '-'
+          ])}
+        />
+      </div>
 
       <div className="bg-white rounded-lg shadow p-4">
         <h3 className="font-semibold mb-2">Productos con menor movimiento</h3>
         {lowMovement.length > 0 ? (
-          <ul className="space-y-1 text-sm">
+          <ul className="space-y-1 text-sm max-h-60 overflow-y-auto">
             {lowMovement.map((p) => (
               <li key={p.id} className="flex justify-between">
                 <span>{p.name}</span>

--- a/frontend/src/pages/ReportesVentas.jsx
+++ b/frontend/src/pages/ReportesVentas.jsx
@@ -126,19 +126,21 @@ function ReportesVentas() {
         </button>
       </div>
 
-      <DataTable
-        headers={["Fecha", "ID", "Cliente", "Total", "Vendedor"]}
-        rows={filtered.map((s) => [
-          new Date(s.sale_date).toLocaleDateString(),
-          s.id,
-          `${s.client_first_name} ${s.client_last_name}`,
-          parseFloat(s.total).toLocaleString('es-CL', {
-            minimumFractionDigits: 0,
-            maximumFractionDigits: 0
-          }),
-          users.find((u) => u.id === s.agent)?.username || s.agent
-        ])}
-      />
+      <div className="max-h-[60vh] overflow-y-auto">
+        <DataTable
+          headers={["Fecha", "ID", "Cliente", "Total", "Vendedor"]}
+          rows={filtered.map((s) => [
+            new Date(s.sale_date).toLocaleDateString(),
+            s.id,
+            `${s.client_first_name} ${s.client_last_name}`,
+            parseFloat(s.total).toLocaleString('es-CL', {
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0
+            }),
+            users.find((u) => u.id === s.agent)?.username || s.agent
+          ])}
+        />
+      </div>
 
       <div className="bg-white p-4 rounded-lg shadow">
         <h3 className="font-semibold mb-2">Ventas por día</h3>
@@ -154,7 +156,12 @@ function ReportesVentas() {
 
       <div className="bg-white p-4 rounded-lg shadow">
         <h3 className="font-semibold mb-2">Top 10 productos</h3>
-        <DataTable headers={["Producto", "Cantidad"]} rows={topProducts.map((t) => [t.name, t.qty])} />
+        <div className="max-h-[60vh] overflow-y-auto">
+          <DataTable
+            headers={["Producto", "Cantidad"]}
+            rows={topProducts.map((t) => [t.name, t.qty])}
+          />
+        </div>
       </div>
 
       {loading && <p className="text-sm">Cargando...</p>}


### PR DESCRIPTION
## Summary
- limit data table heights on report pages
- add scrollbars for longer lists

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687fca98a834832c86869e561efccad6