### PR TITLE
Add detailed sales modal

### DIFF
--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-function DataTable({ headers, rows }) {
+function DataTable({ headers, rows, onRowClick }) {
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full divide-y divide-gray-200">
@@ -18,7 +18,11 @@ function DataTable({ headers, rows }) {
         </thead>
         <tbody className="bg-white divide-y divide-gray-100">
           {rows.map((row, i) => (
-            <tr key={i} className="hover:bg-gray-50">
+            <tr
+              key={i}
+              className={`hover:bg-gray-50 ${onRowClick ? 'cursor-pointer' : ''}`}
+              onClick={onRowClick ? () => onRowClick(row, i) : undefined}
+            >
               {row.map((cell, j) => (
                 <td key={j} className="px-3 py-2 text-sm text-gray-700">
                   {cell}

--- a/frontend/src/pages/ReportesVentas.jsx
+++ b/frontend/src/pages/ReportesVentas.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import DataTable from '@components/DataTable.jsx'
-import { fetchAll } from '../api.js'
+import { fetchAll, API_BASE, authHeaders } from '../api.js'
 
 function ReportesVentas() {
   const today = new Date().toISOString().slice(0, 10)
@@ -14,6 +14,8 @@ function ReportesVentas() {
   const [prodFilter, setProdFilter] = useState('')
   const [topProducts, setTopProducts] = useState([])
   const [loading, setLoading] = useState(false)
+  const [selectedSale, setSelectedSale] = useState(null)
+  const [receiptUrl, setReceiptUrl] = useState('')
 
   const loadData = async () => {
     setLoading(true)
@@ -65,8 +67,27 @@ function ReportesVentas() {
   })
   const maxVal = Math.max(...Object.values(daily), 1)
 
+  const productMap = Object.fromEntries(products.map((p) => [p.id, p]))
+
+  const openSale = async (sale) => {
+    setSelectedSale(sale)
+    setReceiptUrl('')
+    try {
+      const resp = await fetch(
+        `${API_BASE}/sales/${sale.id}/export/`,
+        { headers: authHeaders() }
+      )
+      if (resp.ok) {
+        const data = await resp.json()
+        setReceiptUrl(data.pdf_url)
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   return (
-    <div className="p-6 space-y-6 bg-gray-50 min-h-screen">
+    <div className="h-screen p-6 space-y-6 bg-gray-50 overflow-hidden">
       <h2 className="text-3xl font-bold text-gray-800 mb-4">Reporte de Ventas</h2>
 
       <div className="flex flex-wrap items-end gap-4">
@@ -139,6 +160,7 @@ function ReportesVentas() {
             }),
             users.find((u) => u.id === s.agent)?.username || s.agent
           ])}
+          onRowClick={(row, i) => openSale(filtered[i])}
         />
       </div>
 
@@ -165,6 +187,75 @@ function ReportesVentas() {
       </div>
 
       {loading && <p className="text-sm">Cargando...</p>}
+
+      {selectedSale && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md flex flex-col overflow-hidden">
+            <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white p-4 flex justify-between items-center">
+              <h3 className="text-xl font-semibold">Venta #{selectedSale.id}</h3>
+              <button
+                type="button"
+                onClick={() => setSelectedSale(null)}
+                className="bg-white/10 hover:bg-white/20 text-white rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 flex items-center gap-2"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                Cerrar
+              </button>
+            </div>
+            <div className="p-6 space-y-4 overflow-y-auto text-sm flex-1">
+              <p>
+                <span className="font-medium">Cliente:</span>{' '}
+                {selectedSale.client_first_name} {selectedSale.client_last_name}
+              </p>
+              <p>
+                <span className="font-medium">RUT:</span> {selectedSale.client_rut}
+              </p>
+              <p>
+                <span className="font-medium">Fecha:</span>{' '}
+                {new Date(selectedSale.sale_date).toLocaleString()}
+              </p>
+              <p>
+                <span className="font-medium">Total:</span>{' '}
+                {parseFloat(selectedSale.total).toLocaleString('es-CL', {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 0
+                })}
+              </p>
+            </div>
+            <div>
+              <h4 className="font-medium text-gray-800 mb-2">Detalles</h4>
+              <ul className="space-y-1 max-h-60 overflow-y-auto text-sm">
+                {selectedSale.details.map((d, i) => (
+                  <li key={i} className="flex justify-between items-start">
+                    <div>
+                      <p>{productMap[d.product_id]?.name || `Producto ${d.product_id}`}</p>
+                      {productMap[d.product_id]?.barcode && (
+                        <p className="text-xs text-gray-500">Cod: {productMap[d.product_id].barcode}</p>
+                      )}
+                    </div>
+                    <span className="text-gray-700">x{d.quantity}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            {receiptUrl && (
+              <div className="pt-4 flex justify-end">
+                <a
+                  href={receiptUrl}
+                  download
+                  target="_blank"
+                  rel="noreferrer"
+                  className="bg-blue-600 hover:bg-blue-700 text-white rounded-lg px-4 py-2 text-sm font-medium transition-colors duration-200"
+                >
+                  Descargar Boleta
+                </a>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- allow row click events in DataTable
- improve ReportesVentas with a detail modal and internal scrolling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687fcd0bf378832c8bb50ca8dd0ef707