### PR TITLE
Fix products page access by defaulting API base URL

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,7 @@
-export const API_BASE = import.meta.env.VITE_API_BASE;
+// Default the API base URL to localhost if not provided via environment
+// variable. This prevents runtime errors when VITE_API_BASE is undefined.
+export const API_BASE =
+  import.meta.env.VITE_API_BASE || 'http://localhost:8000/api';
 
 export function authHeaders() {
   const token = localStorage.getItem('access');


### PR DESCRIPTION
## Summary
- handle missing `VITE_API_BASE` env variable by defaulting API base URL

## Testing
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886f9d87060832c88689e510fe195c7