### PR TITLE
Switch to SQLite

### DIFF
--- a/Backend/muebleria/settings.py
+++ b/Backend/muebleria/settings.py
@@ -119,16 +119,11 @@ CORS_ALLOWED_ORIGINS = [
 
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
-from decouple import config
-
+# Use SQLite database stored in project root "bd" directory
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': config('DB_NAME'),
-        'USER': config('DB_USER'),
-        'PASSWORD': config('DB_PASSWORD'),
-        'HOST': config('DB_HOST', default='127.0.0.1'),
-        'PORT': config('DB_PORT', default='3306'),
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR.parent / 'bd' / 'db.sqlite3',
     }
 }
 


### PR DESCRIPTION
## Summary
- switch DB engine from MySQL to SQLite
- store database file in new `bd` directory

## Testing
- `python Backend/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6887b6a38a90832c83ab4a332e54fef2