### PR TITLE
Update dashboard defaults

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -111,7 +111,8 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route element={<Layout user={user} onLogout={handleLogout} />}>
+        <Route element={<Layout user={user} onLogout={handleLogout} />}> 
+          <Route index element={<Navigate to="/dashboard" replace />} />
           <Route
             path="/dashboard"
             element={
@@ -174,7 +175,7 @@ function App() {
               </RequireSuperuser>
             }
           />
-          <Route path="*" element={<Navigate to="/inventario" replace />} />
+          <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -39,7 +39,8 @@ function Dashboard() {
     weekStart.setDate(weekStart.getDate() - diff)
     weekStart.setHours(0, 0, 0, 0)
     const weekEnd = new Date(weekStart)
-    weekEnd.setDate(weekStart.getDate() + 6)
+    weekEnd.setDate(weekStart.getDate() + 7)
+    weekEnd.setMilliseconds(-1)
 
     const salesWeek = sales.filter((s) => {
       const d = new Date(s.sale_date)
@@ -79,7 +80,14 @@ function Dashboard() {
         <div className="flex items-end h-48 gap-3">
           {Object.entries(weekly).map(([d, val]) => (
             <div key={d} className="flex-1 flex flex-col items-center">
-              <div className="w-4 bg-blue-500" style={{ height: `${(val / maxVal) * 100}%` }}></div>
+              <div
+                className="w-4 bg-blue-500 relative"
+                style={{ height: `${(val / maxVal) * 100}%` }}
+              >
+                <span className="absolute -top-5 left-1/2 -translate-x-1/2 text-xs font-medium">
+                  {val.toLocaleString('es-CL', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+                </span>
+              </div>
               <span className="text-xs mt-1">{d}</span>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- redirect to dashboard after login
- include index route redirect
- improve weekly sales chart logic and display

## Testing
- `python Backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6887b9e246a8832cadabf89ecba05ae5