### PR TITLE
feat: add protected superadmin registration

### DIFF
--- a/Backend/users/serializers.py
+++ b/Backend/users/serializers.py
@@ -40,14 +40,25 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         fields = ['id', 'username', 'email', 'password', 'role']
 
     def create(self, validated_data):
+        """Create a regular user or a superuser based on role."""
         role = validated_data.pop('role', 'recepcionist')
-        user = User.objects.create_user(
-            username=validated_data['username'],
-            email=validated_data.get('email'),
-            password=validated_data['password']
-        )
-        user.role = role
-        user.save()
+
+        if role == 'admin':
+            # Use Django's create_superuser to ensure proper flags are set
+            user = User.objects.create_superuser(
+                username=validated_data['username'],
+                email=validated_data.get('email'),
+                password=validated_data['password'],
+            )
+        else:
+            user = User.objects.create_user(
+                username=validated_data['username'],
+                email=validated_data.get('email'),
+                password=validated_data['password'],
+            )
+            user.role = role
+            user.save()
+
         return user
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,8 @@ import FinancialReports from './pages/FinancialReports.jsx'
 import Quotes from './pages/Quotes.jsx'
 import Users from './pages/Users.jsx'
 import ImportExport from './pages/ImportExport.jsx'
+import RegisterAccess from './pages/RegisterAccess.jsx'
+import RegisterSuperAdmin from './pages/RegisterSuperAdmin.jsx'
 
 function RequireSuperuser({ children, user }) {
   if (!user?.is_superuser) {
@@ -102,9 +104,14 @@ function App() {
 
   if (!token) {
     return (
-      <div className="">
-        <Login onSuccess={handleLogin} />
-      </div>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Login onSuccess={handleLogin} />} />
+          <Route path="/register-access" element={<RegisterAccess />} />
+          <Route path="/register-superadmin" element={<RegisterSuperAdmin />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </BrowserRouter>
     )
   }
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { API_BASE } from '../api.js'
 
 function Login({ onSuccess }) {
@@ -6,6 +7,7 @@ function Login({ onSuccess }) {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const navigate = useNavigate()
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -106,6 +108,16 @@ function Login({ onSuccess }) {
               )}
             </button>
           </form>
+
+          <div className="mt-4 text-center">
+            <button
+              type="button"
+              onClick={() => navigate('/register-access')}
+              className="text-sm text-blue-600 hover:underline"
+            >
+              Registrar Super Admin
+            </button>
+          </div>
 
           {/* Footer */}
           <div className="mt-8 text-center">

--- a/frontend/src/pages/RegisterAccess.jsx
+++ b/frontend/src/pages/RegisterAccess.jsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+const ACCESS_USER = 'superadmin'
+const ACCESS_PASS = 'superadmin123'
+
+function RegisterAccess() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const navigate = useNavigate()
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    if (username === ACCESS_USER && password === ACCESS_PASS) {
+      navigate('/register-superadmin')
+    } else {
+      setError('Credenciales incorrectas')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 p-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-2xl p-8">
+          <h1 className="text-2xl font-bold text-gray-800 mb-6 text-center">Acceso al Registro</h1>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-2">
+                Usuario
+              </label>
+              <input
+                id="username"
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 bg-gray-50 focus:bg-white"
+                required
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
+                Contraseña
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 bg-gray-50 focus:bg-white"
+                required
+              />
+            </div>
+            {error && <p className="text-red-600 text-sm">{error}</p>}
+            <button
+              type="submit"
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200"
+            >
+              Entrar
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default RegisterAccess

--- a/frontend/src/pages/RegisterSuperAdmin.jsx
+++ b/frontend/src/pages/RegisterSuperAdmin.jsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { API_BASE } from '../api.js'
+
+function RegisterSuperAdmin() {
+  const [form, setForm] = useState({ username: '', email: '', password: '' })
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const navigate = useNavigate()
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+    try {
+      const resp = await fetch(`${API_BASE}/register/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...form, role: 'admin' }),
+      })
+      if (!resp.ok) {
+        throw new Error('Error al registrar')
+      }
+      setSuccess('Registrado exitosamente')
+      setTimeout(() => navigate('/'), 1500)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 p-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white rounded-2xl shadow-2xl p-8">
+          <h1 className="text-2xl font-bold text-gray-800 mb-6 text-center">Registro Super Admin</h1>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Usuario</label>
+              <input
+                name="username"
+                value={form.username}
+                onChange={handleChange}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 bg-gray-50 focus:bg-white"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Correo</label>
+              <input
+                name="email"
+                type="email"
+                value={form.email}
+                onChange={handleChange}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 bg-gray-50 focus:bg-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Contraseña</label>
+              <input
+                name="password"
+                type="password"
+                value={form.password}
+                onChange={handleChange}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200 bg-gray-50 focus:bg-white"
+                required
+              />
+            </div>
+            {error && <p className="text-red-600 text-sm">{error}</p>}
+            {success && <p className="text-green-600 text-sm">{success}</p>}
+            <button
+              type="submit"
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-all duration-200"
+            >
+              Registrar
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default RegisterSuperAdmin


### PR DESCRIPTION
## Summary
- allow serializer to create superusers when role is admin
- add login link and routes for protected superadmin registration
- implement access check and registration forms for superadmin

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'drf_spectacular')*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ReceiptModal unused variable, Inventory unused import, Quotes unused variable, SalesReports unused vars, vite.config undefined `__dirname`)*

------
https://chatgpt.com/codex/tasks/task_e_688d96e62044832c8a4a42c7a0966676