### PR TITLE
feat: gate superadmin registration

### DIFF
--- a/frontend/src/pages/RegisterAccess.jsx
+++ b/frontend/src/pages/RegisterAccess.jsx
@@ -13,6 +13,7 @@ function RegisterAccess() {
   const handleSubmit = (e) => {
     e.preventDefault()
     if (username === ACCESS_USER && password === ACCESS_PASS) {
+      sessionStorage.setItem('registerAccess', 'true')
       navigate('/register-superadmin')
     } else {
       setError('Credenciales incorrectas')

--- a/frontend/src/pages/RegisterSuperAdmin.jsx
+++ b/frontend/src/pages/RegisterSuperAdmin.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { API_BASE } from '../api.js'
 
@@ -7,6 +7,16 @@ function RegisterSuperAdmin() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
   const navigate = useNavigate()
+
+  useEffect(() => {
+    if (sessionStorage.getItem('registerAccess') !== 'true') {
+      navigate('/register-access', { replace: true })
+    }
+  }, [navigate])
+
+  useEffect(() => {
+    return () => sessionStorage.removeItem('registerAccess')
+  }, [])
 
   const handleChange = (e) => {
     const { name, value } = e.target


### PR DESCRIPTION
## Summary
- require hardcoded credentials to reach super admin registration
- verify session storage to avoid direct access

## Testing
- `python manage.py test` *(fails: No module named 'drf_spectacular')*
- `pip install drf-spectacular` *(fails: Could not find a version that satisfies the requirement drf-spectacular)*
- `npm run lint` *(fails: 13 problems (6 errors, 7 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688d9cefa46c832c8be456253606f344