### PR TITLE
Scale base font size with viewport

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,15 @@
-@import 'tailwindcss'
+@import 'tailwindcss';
+
+/* Scale the base font size with viewport width so layouts designed for
+   1920px wide screens scale proportionally on smaller resolutions.
+   1920 / 16 = 120, so 1rem equals 16px at 1920px width. */
+html {
+  font-size: calc(100vw / 120);
+}
+
+/* Prevent the layout from growing larger than the original design. */
+@media (min-width: 1920px) {
+  html {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## Summary
- scale base font-size relative to viewport width for consistent layout on 1366×768 screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React Hook missing dependency, unused vars, __dirname not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688e2c4ce834832cb96a8ba74b355f17