### PR TITLE
Enable PDF export for sales receipts

### DIFF
--- a/Backend/core/views/sales.py
+++ b/Backend/core/views/sales.py
@@ -4,6 +4,12 @@ from core.serializers.sales import SaleSerializer
 from rest_framework.permissions import IsAuthenticated
 from drf_spectacular.utils import extend_schema
 from drf_spectacular.utils import OpenApiParameter
+from rest_framework.decorators import action
+from django.template.loader import get_template
+from xhtml2pdf import pisa
+from django.conf import settings
+from rest_framework.response import Response
+import os
 
 
 @extend_schema(tags=["Ventas"])
@@ -11,6 +17,24 @@ class SaleViewSet(viewsets.ModelViewSet):
     queryset = Sale.objects.all().order_by('-sale_date')
     serializer_class = SaleSerializer
     permission_classes = [IsAuthenticated]
+
+    @action(detail=True, methods=['get'], url_path='export')
+    def export_pdf(self, request, pk=None):
+        sale = self.get_object()
+        template = get_template('sales/ticket.html')
+        logo_path = os.path.join(settings.BASE_DIR, 'static', 'logo.png')
+        context = {'sale': sale, 'logo_path': logo_path}
+        html = template.render(context)
+
+        folder_path = os.path.join(settings.MEDIA_ROOT, 'sales')
+        os.makedirs(folder_path, exist_ok=True)
+        file_name = f"boleta_{sale.id}.pdf"
+        file_path = os.path.join(folder_path, file_name)
+
+        with open(file_path, "wb") as pdf_file:
+            pisa.CreatePDF(html, dest=pdf_file)
+        file_url = request.build_absolute_uri(settings.MEDIA_URL + f"sales/{file_name}")
+        return Response({"pdf_url": file_url})
 
     @extend_schema(
         summary="Registrar venta o listar historial",


### PR DESCRIPTION
## Summary
- add PDF export endpoint for sales receipts

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e96a15e64832c815494b1f759b81f