### PR TITLE
Handle non-UTF8 CSV import

### DIFF
--- a/Backend/core/views/import_export.py
+++ b/Backend/core/views/import_export.py
@@ -50,7 +50,12 @@ class ProductImportExportView(APIView):
         file = request.FILES.get('file')
         if not file:
             return Response({'error': 'No file provided'}, status=400)
-        decoded = file.read().decode('utf-8').splitlines()
+        data = file.read()
+        try:
+            decoded = data.decode('utf-8')
+        except UnicodeDecodeError:
+            decoded = data.decode('latin-1')
+        decoded = decoded.splitlines()
         reader = csv.DictReader(decoded)
         created = 0
         for row in reader:


### PR DESCRIPTION
## Summary
- tolerate non-UTF8 encodings when importing CSVs by falling back to latin-1

## Testing
- `cd Backend && python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688fa8e20220832c83ddf4ba9a1ee951